### PR TITLE
Display patient and specialist records separately

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -28,7 +28,7 @@ DoConnek Pro is a **desktop app** that helps **General Practitioner Clinic Manag
 
    * `add -pa n/John p/12345678 a/21 m/Osteoporosis m/Rheumatoid arthritis` : Adds a patient named `John` to the list.
 
-   * `delete -pa 3` : Deletes the 3rd patient shown in the current list.
+   * `delete 3` : Deletes the 3rd person shown in the current list.
 
    * `clear` : Deletes all contacts.
 
@@ -121,15 +121,15 @@ Examples:
 
 Deletes the specified patient or specialist from the stored records.
 
-Format: `delete -PERSON_TYPE INDEX`
+Format: `delete INDEX`
 
 * Deletes the person at the specified `INDEX`.
 * The index refers to the index number shown in the displayed person list.
 * The index **must be a positive integer** 1, 2, 3, …​ with a maximum value of the list size.
 
 Examples:
-* `list -pa` followed by `delete -pa 2` deletes the 2nd patient in the listed patients. 
-* `find -sp Betsy` followed by `delete -sp 1` deletes the 1st specialist from the specialists listed in the `find` command.
+* `list -pa` followed by `delete 2` deletes the 2nd patient in the listed patients. 
+* `find -sp Betsy` followed by `delete 1` deletes the 1st specialist from the specialists listed in the `find` command.
 
 ### Clearing all entries : `clear`
 
@@ -181,7 +181,7 @@ Action | Format, Examples
 **Add (patient)** | `add -pa n/NAME p/PHONE_NUMBER a/AGE [m/MEDICAL_HISTORY]...` <br> e.g., `add -pa n/John p/12345678 a/21 m/Osteoporosis m/Rheumatoid arthritis`
 **Add (specialist)** | `add -sp n/NAME p/PHONE_NUMBER s/SPECIALISATION l/LOCATION` <br> e.g., `add -sp n/Jane p/73331515 s/Dermatologist l/Ang Mo Kio`
 **Clear** | `clear`
-**Delete** | `delete -PERSON_TYPE INDEX`<br> e.g., `delete -pa 3`
+**Delete** | `delete INDEX`<br> e.g., `delete 3`
 **Find** | `find -PERSON_TYPE KEYWORD [MORE_KEYWORDS]`<br> e.g., `find -pa James Jake`
 **List** | `list -pa`
 **Help** | `help`

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -12,7 +12,6 @@ import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.PersonType;
 
 /**
  * Deletes a person identified using it's displayed index from the address book.
@@ -33,15 +32,12 @@ public class DeleteCommand extends Command {
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
 
     private final Index targetIndex;
-    private final PersonType personType;
 
     /**
      * @param targetIndex of the person in the list to delete
-     * @param personType The type of person being deleted i.e. patient or specialist
      */
-    public DeleteCommand(Index targetIndex, PersonType personType) {
+    public DeleteCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
-        this.personType = personType;
     }
 
     @Override
@@ -70,14 +66,13 @@ public class DeleteCommand extends Command {
         }
 
         DeleteCommand otherDeleteCommand = (DeleteCommand) other;
-        return targetIndex.equals(otherDeleteCommand.targetIndex) && personType.equals(otherDeleteCommand.personType);
+        return targetIndex.equals(otherDeleteCommand.targetIndex);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
                 .add("targetIndex", targetIndex)
-                .add("personType", personType)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -29,7 +29,6 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Patient;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.PersonType;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Specialist;
 import seedu.address.model.person.Specialty;
@@ -68,14 +67,11 @@ public class EditCommand extends Command {
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
 
-    private final PersonType personType;
-
     /**
      * @param index                of the person in the filtered person list to edit
      * @param editPersonDescriptor details to edit the person with
-     * @param personType The type of person being edited i.e. patient or specialist
      */
-    public EditCommand(Index index, EditPersonDescriptor editPersonDescriptor, PersonType personType) {
+    public EditCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
         requireNonNull(index);
         requireNonNull(editPersonDescriptor);
 
@@ -85,7 +81,6 @@ public class EditCommand extends Command {
         } else {
             this.editPersonDescriptor = new EditSpecialistDescriptor((EditSpecialistDescriptor) editPersonDescriptor);
         }
-        this.personType = personType;
     }
 
     @Override
@@ -117,7 +112,6 @@ public class EditCommand extends Command {
         }
 
         model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(personType.getSearchPredicate());
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
     }
 
@@ -169,8 +163,7 @@ public class EditCommand extends Command {
 
         EditCommand otherEditCommand = (EditCommand) other;
         return index.equals(otherEditCommand.index)
-                && editPersonDescriptor.equals(otherEditCommand.editPersonDescriptor)
-                && personType.equals(otherEditCommand.personType);
+                && editPersonDescriptor.equals(otherEditCommand.editPersonDescriptor);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -9,7 +9,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SPECIALTY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.SPECIALIST_TAG;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -30,6 +29,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Patient;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonType;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Specialist;
 import seedu.address.model.person.Specialty;
@@ -68,11 +68,14 @@ public class EditCommand extends Command {
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
 
+    private final PersonType personType;
+
     /**
-     * @param index of the person in the filtered person list to edit
+     * @param index                of the person in the filtered person list to edit
      * @param editPersonDescriptor details to edit the person with
+     * @param personType The type of person being edited i.e. patient or specialist
      */
-    public EditCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
+    public EditCommand(Index index, EditPersonDescriptor editPersonDescriptor, PersonType personType) {
         requireNonNull(index);
         requireNonNull(editPersonDescriptor);
 
@@ -82,6 +85,7 @@ public class EditCommand extends Command {
         } else {
             this.editPersonDescriptor = new EditSpecialistDescriptor((EditSpecialistDescriptor) editPersonDescriptor);
         }
+        this.personType = personType;
     }
 
     @Override
@@ -113,7 +117,7 @@ public class EditCommand extends Command {
         }
 
         model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredPersonList(personType.getSearchPredicate());
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -169,7 +169,8 @@ public class EditCommand extends Command {
 
         EditCommand otherEditCommand = (EditCommand) other;
         return index.equals(otherEditCommand.index)
-                && editPersonDescriptor.equals(otherEditCommand.editPersonDescriptor);
+                && editPersonDescriptor.equals(otherEditCommand.editPersonDescriptor)
+                && personType.equals(otherEditCommand.personType);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -1,8 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PATIENTS;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_SPECIALISTS;
 
 import seedu.address.model.Model;
 import seedu.address.model.person.PersonType;
@@ -31,13 +29,10 @@ public class ListCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        if (personType == PersonType.PATIENT) {
-            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PATIENTS);
-            return new CommandResult(PATIENT_MESSAGE_SUCCESS);
-        } else {
-            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_SPECIALISTS);
-            return new CommandResult(SPECIALIST_MESSAGE_SUCCESS);
-        }
+        model.updateFilteredPersonList(personType.getSearchPredicate());
+        return new CommandResult(personType == PersonType.PATIENT
+                ? PATIENT_MESSAGE_SUCCESS
+                : SPECIALIST_MESSAGE_SUCCESS);
 
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -1,9 +1,11 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PATIENTS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_SPECIALISTS;
 
 import seedu.address.model.Model;
+import seedu.address.model.person.PersonType;
 
 /**
  * Lists all persons in the address book to the user.
@@ -12,13 +14,30 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all persons";
+    public static final String PATIENT_MESSAGE_SUCCESS = "Listed all patients";
+
+    public static final String SPECIALIST_MESSAGE_SUCCESS = "Listed all specialists";
+
+    private final PersonType personType;
+
+    /**
+     * @param personType The type of person being listed i.e. patient or specialist
+     */
+    public ListCommand(PersonType personType) {
+        this.personType = personType;
+    }
 
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS);
+        if (personType == PersonType.PATIENT) {
+            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PATIENTS);
+            return new CommandResult(PATIENT_MESSAGE_SUCCESS);
+        } else {
+            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_SPECIALISTS);
+            return new CommandResult(SPECIALIST_MESSAGE_SUCCESS);
+        }
+
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -27,7 +27,7 @@ import seedu.address.model.tag.Tag;
 /**
  * Parses input arguments and creates a new AddCommand object
  */
-public class AddCommandParser implements Parser<AddCommand> {
+public class AddCommandParser implements ParserComplex<AddCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -29,15 +29,15 @@ import seedu.address.model.person.PersonType;
 public class AddressBookParser {
 
     /**
-     * Used for initial separation of command word and args.
+     * Used for initial separation of command word and args. Basic commands do not require a person type tag.
      */
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile(
             "(?<commandWord>\\S+)(?<arguments>.*)");
     /**
-     * Used for initial separation of command word, person type and args.
+     * Used for initial separation of command word, person type and args. Complex commands require a person type tag.
      */
-    private static final Pattern PERSON_TYPE_COMMAND_FORMAT = Pattern.compile(
-            "(?<commandWord>\\S+)\\s(?<personType>\\S+)(?<arguments>.*)");
+    private static final Pattern COMPLEX_COMMAND_FORMAT = Pattern.compile(
+            "(?<commandWord>\\S+)\\s(?<personType>-\\S+)(?<arguments>.*)");
     private static final Logger logger = LogsCenter.getLogger(AddressBookParser.class);
 
     /**
@@ -49,7 +49,7 @@ public class AddressBookParser {
      */
     public Command parseCommand(String userInput) throws ParseException {
         final Matcher matcherBasic = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
-        final Matcher matcherPersonType = PERSON_TYPE_COMMAND_FORMAT.matcher(userInput.trim());
+        final Matcher matcherPersonType = COMPLEX_COMMAND_FORMAT.matcher(userInput.trim());
 
         if (matcherPersonType.matches()) {
             final String commandWord = matcherPersonType.group("commandWord");
@@ -80,9 +80,6 @@ public class AddressBookParser {
             case EditCommand.COMMAND_WORD:
                 return new EditCommandParser().parse(personType, arguments);
 
-            case DeleteCommand.COMMAND_WORD:
-                return new DeleteCommandParser().parse(personType, arguments);
-
             case FindCommand.COMMAND_WORD:
                 return new FindCommandParser().parse(personType, arguments);
 
@@ -105,6 +102,9 @@ public class AddressBookParser {
             logger.fine("Command word: " + commandWord + "; Arguments: " + arguments);
 
             switch (commandWord) {
+
+            case DeleteCommand.COMMAND_WORD:
+                return new DeleteCommandParser().parse(arguments);
 
             case ClearCommand.COMMAND_WORD:
                 return new ClearCommand();

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -87,7 +87,7 @@ public class AddressBookParser {
                 return new FindCommandParser().parse(personType, arguments);
 
             case ListCommand.COMMAND_WORD:
-                return new ListCommand();
+                return new ListCommand(personType);
 
             default:
                 logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -5,19 +5,18 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.PersonType;
 
 /**
  * Parses input arguments and creates a new DeleteCommand object
  */
-public class DeleteCommandParser implements Parser<DeleteCommand> {
+public class DeleteCommandParser implements ParserBasic<DeleteCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteCommand
      * and returns a DeleteCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public DeleteCommand parse(PersonType personType, String args) throws ParseException {
+    public DeleteCommand parse(String args) throws ParseException {
         try {
             Index index = ParserUtil.parseIndex(args);
             return new DeleteCommand(index);

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -20,7 +20,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
     public DeleteCommand parse(PersonType personType, String args) throws ParseException {
         try {
             Index index = ParserUtil.parseIndex(args);
-            return new DeleteCommand(index, personType);
+            return new DeleteCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -74,7 +74,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (!editPatientDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
         }
-        return new EditCommand(index, editPatientDescriptor);
+        return new EditCommand(index, editPatientDescriptor, PersonType.PATIENT);
     }
     private EditCommand parseSpecialist(String args) throws ParseException {
         ArgumentMultimap argMultimap =
@@ -114,7 +114,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (!editSpecialistDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
         }
-        return new EditCommand(index, editSpecialistDescriptor);
+        return new EditCommand(index, editSpecialistDescriptor, PersonType.SPECIALIST);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -25,7 +25,7 @@ import seedu.address.model.tag.Tag;
 /**
  * Parses input arguments and creates a new EditCommand object
  */
-public class EditCommandParser implements Parser<EditCommand> {
+public class EditCommandParser implements ParserComplex<EditCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the EditCommand
@@ -74,7 +74,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (!editPatientDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
         }
-        return new EditCommand(index, editPatientDescriptor, PersonType.PATIENT);
+        return new EditCommand(index, editPatientDescriptor);
     }
     private EditCommand parseSpecialist(String args) throws ParseException {
         ArgumentMultimap argMultimap =
@@ -114,7 +114,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (!editSpecialistDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
         }
-        return new EditCommand(index, editSpecialistDescriptor, PersonType.SPECIALIST);
+        return new EditCommand(index, editSpecialistDescriptor);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -12,7 +12,7 @@ import seedu.address.model.person.PersonType;
 /**
  * Parses input arguments and creates a new FindCommand object
  */
-public class FindCommandParser implements Parser<FindCommand> {
+public class FindCommandParser implements ParserComplex<FindCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand

--- a/src/main/java/seedu/address/logic/parser/ParserBasic.java
+++ b/src/main/java/seedu/address/logic/parser/ParserBasic.java
@@ -2,16 +2,15 @@ package seedu.address.logic.parser;
 
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.PersonType;
 
 /**
- * Represents a Parser that is able to parse user input into a {@code Command} of type {@code T}.
+ * Represents a ParserBasic that is able to parse basic user input into a {@code Command} of type {@code T}.
  */
-public interface Parser<T extends Command> {
+public interface ParserBasic<T extends Command> {
 
     /**
      * Parses {@code userInput} into a command and returns it.
      * @throws ParseException if {@code userInput} does not conform the expected format
      */
-    T parse(PersonType personType, String userInput) throws ParseException;
+    T parse(String userInput) throws ParseException;
 }

--- a/src/main/java/seedu/address/logic/parser/ParserComplex.java
+++ b/src/main/java/seedu/address/logic/parser/ParserComplex.java
@@ -1,0 +1,17 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.PersonType;
+
+/**
+ * Represents a ParserComplex that is able to parse complex user input into a {@code Command} of type {@code T}.
+ */
+public interface ParserComplex<T extends Command> {
+
+    /**
+     * Parses {@code userInput} into a command and returns it.
+     * @throws ParseException if {@code userInput} does not conform the expected format
+     */
+    T parse(PersonType personType, String userInput) throws ParseException;
+}

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -17,7 +17,7 @@ import seedu.address.model.person.Specialty;
 import seedu.address.model.tag.Tag;
 
 /**
- * Contains utility methods used for parsing strings in the various *Parser classes.
+ * Contains utility methods used for parsing strings in the various *ParserComplex classes.
  */
 public class ParserUtil {
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,14 +5,23 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.person.Patient;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Specialist;
 
 /**
  * The API of the Model component.
  */
 public interface Model {
-    /** {@code Predicate} that always evaluate to true */
+    /** {@code Predicate} that always evaluates to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
+
+    /** {@code Predicate} that evaluates to true when {@code Person} is a {@code Patient}*/
+    Predicate<Person> PREDICATE_SHOW_ALL_PATIENTS = person -> person instanceof Patient;
+
+    /** {@code Predicate} that evaluates to true when {@code Person} is a {@code Specialist}*/
+    Predicate<Person> PREDICATE_SHOW_ALL_SPECIALISTS = person -> person instanceof Specialist;
+
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -16,13 +16,6 @@ public interface Model {
     /** {@code Predicate} that always evaluates to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
 
-    /** {@code Predicate} that evaluates to true when {@code Person} is a {@code Patient}*/
-    Predicate<Person> PREDICATE_SHOW_ALL_PATIENTS = person -> person instanceof Patient;
-
-    /** {@code Predicate} that evaluates to true when {@code Person} is a {@code Specialist}*/
-    Predicate<Person> PREDICATE_SHOW_ALL_SPECIALISTS = person -> person instanceof Specialist;
-
-
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,9 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.model.person.Patient;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.Specialist;
 
 /**
  * The API of the Model component.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,8 +11,8 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.model.person.Patient;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonType;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -35,7 +35,9 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
-        updateFilteredPersonList(PREDICATE_SHOW_ALL_PATIENTS);
+
+        // DoConnek Pro shows all patients on startup by default.
+        updateFilteredPersonList(PersonType.PATIENT.getSearchPredicate());
     }
 
     public ModelManager() {

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,6 +11,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.person.Patient;
 import seedu.address.model.person.Person;
 
 /**
@@ -34,6 +35,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        updateFilteredPersonList(PREDICATE_SHOW_ALL_PATIENTS);
     }
 
     public ModelManager() {

--- a/src/main/java/seedu/address/model/person/PersonType.java
+++ b/src/main/java/seedu/address/model/person/PersonType.java
@@ -1,8 +1,22 @@
 package seedu.address.model.person;
 
+import java.util.function.Predicate;
+
 /**
  * This enum encapsulates the types of people that the address book can deal with.
  */
 public enum PersonType {
-    PATIENT, SPECIALIST;
+
+    PATIENT(person -> person instanceof Patient), SPECIALIST(person -> person instanceof Specialist);
+
+    /** {@code Predicate} that evaluates to true when {@code Person} matches the {@code PersonType}*/
+    private final Predicate<Person> searchPredicate;
+
+    PersonType(Predicate<Person> searchPredicate) {
+        this.searchPredicate = searchPredicate;
+    }
+
+    public Predicate<Person> getSearchPredicate() {
+        return searchPredicate;
+    }
 }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -62,7 +62,7 @@ public class LogicManagerTest {
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "delete -pa 9";
+        String deleteCommand = "delete 9";
         assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -69,7 +69,7 @@ public class LogicManagerTest {
     @Test
     public void execute_validCommand_success() throws Exception {
         String listCommand = ListCommand.COMMAND_WORD + " " + CliSyntax.PATIENT_TAG;
-        assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, model);
+        assertCommandSuccess(listCommand, ListCommand.PATIENT_MESSAGE_SUCCESS, model);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -18,7 +18,6 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.PersonType;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
@@ -31,7 +30,7 @@ public class DeleteCommandTest {
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON, PersonType.PATIENT);
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
                 Messages.format(personToDelete));
@@ -45,7 +44,7 @@ public class DeleteCommandTest {
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex, PersonType.SPECIALIST);
+        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
@@ -55,7 +54,7 @@ public class DeleteCommandTest {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON, PersonType.PATIENT);
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
                 Messages.format(personToDelete));
@@ -75,21 +74,21 @@ public class DeleteCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex, PersonType.SPECIALIST);
+        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_PERSON, PersonType.SPECIALIST);
-        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_PERSON, PersonType.SPECIALIST);
+        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_PERSON);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON, PersonType.SPECIALIST);
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false
@@ -100,18 +99,14 @@ public class DeleteCommandTest {
 
         // different person -> returns false
         assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
-
-        // different person types -> returns false
-        DeleteCommand deleteFirstCommandPatient = new DeleteCommand(INDEX_FIRST_PERSON, PersonType.PATIENT);
-        assertFalse(deleteFirstCommand.equals(deleteFirstCommandPatient));
     }
 
     @Test
     public void toStringMethod() {
         Index targetIndex = Index.fromOneBased(1);
-        DeleteCommand deleteCommand = new DeleteCommand(targetIndex, PersonType.PATIENT);
+        DeleteCommand deleteCommand = new DeleteCommand(targetIndex);
         String expected = DeleteCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex
-                + ", personType=" + PersonType.PATIENT + "}";
+                + "}";
         assertEquals(expected, deleteCommand.toString());
     }
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -27,6 +27,7 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Patient;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonType;
 import seedu.address.model.person.Specialist;
 import seedu.address.testutil.EditPatientDescriptorBuilder;
 import seedu.address.testutil.EditSpecialistDescriptorBuilder;
@@ -45,7 +46,7 @@ public class EditCommandTest {
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
         Patient editedPatient = new PatientBuilder().build();
         EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder(editedPatient).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor, PersonType.PATIENT);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPatient));
 
@@ -60,13 +61,13 @@ public class EditCommandTest {
         Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
         Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
 
-        PersonBuilder personInList = new SpecialistBuilder((Specialist) lastPerson);
+        PersonBuilder personInList = new PatientBuilder((Patient) lastPerson);
         Person editedPerson = personInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
                 .withTags(VALID_TAG_HUSBAND).build();
 
-        EditPersonDescriptor descriptor = new EditSpecialistDescriptorBuilder().withName(VALID_NAME_BOB)
+        EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_HUSBAND).build();
-        EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
+        EditCommand editCommand = new EditCommand(indexLastPerson, descriptor, PersonType.PATIENT);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
@@ -78,7 +79,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPatientDescriptor());
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPatientDescriptor(), PersonType.PATIENT);
         Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
@@ -95,7 +96,7 @@ public class EditCommandTest {
         Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person editedPerson = new PatientBuilder((Patient) personInFilteredList).withName(VALID_NAME_BOB).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
-                new EditPatientDescriptorBuilder().withName(VALID_NAME_BOB).build());
+                new EditPatientDescriptorBuilder().withName(VALID_NAME_BOB).build(), PersonType.PATIENT);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
@@ -109,7 +110,7 @@ public class EditCommandTest {
     public void execute_duplicatePersonUnfilteredList_failure() {
         Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder((Patient) firstPerson).build();
-        EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
+        EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor, PersonType.PATIENT);
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
     }
@@ -121,7 +122,7 @@ public class EditCommandTest {
         // edit person in filtered list into a duplicate in address book
         Person personInList = model.getAddressBook().getPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
-                new EditPatientDescriptorBuilder((Patient) personInList).build());
+                new EditPatientDescriptorBuilder((Patient) personInList).build(), PersonType.PATIENT);
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
     }
@@ -130,7 +131,7 @@ public class EditCommandTest {
     public void execute_invalidPersonIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
         EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder().withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
+        EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor, PersonType.PATIENT);
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
@@ -147,18 +148,18 @@ public class EditCommandTest {
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
         EditCommand editCommand = new EditCommand(outOfBoundIndex,
-                new EditPatientDescriptorBuilder().withName(VALID_NAME_BOB).build());
+                new EditPatientDescriptorBuilder().withName(VALID_NAME_BOB).build(), PersonType.PATIENT);
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
     public void equals() {
-        final EditCommand standardCommand = new EditCommand(INDEX_FIRST_PERSON, DESC_AMY);
+        final EditCommand standardCommand = new EditCommand(INDEX_FIRST_PERSON, DESC_AMY, PersonType.PATIENT);
 
         // same values -> returns true
         EditPersonDescriptor copyDescriptor = new EditPatientDescriptor((EditPatientDescriptor) DESC_AMY);
-        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST_PERSON, copyDescriptor);
+        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST_PERSON, copyDescriptor, PersonType.PATIENT);
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
@@ -171,17 +172,17 @@ public class EditCommandTest {
         assertFalse(standardCommand.equals(new ClearCommand()));
 
         // different index -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_PERSON, DESC_AMY)));
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_PERSON, DESC_AMY, PersonType.PATIENT)));
 
         // different descriptor -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_PERSON, DESC_BOB)));
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_PERSON, DESC_BOB, PersonType.PATIENT)));
     }
 
     @Test
     public void toStringMethod() {
         Index index = Index.fromOneBased(1);
         EditPersonDescriptor editPersonDescriptor = new EditPatientDescriptor();
-        EditCommand editCommand = new EditCommand(index, editPersonDescriptor);
+        EditCommand editCommand = new EditCommand(index, editPersonDescriptor, PersonType.PATIENT);
         String expected = EditCommand.class.getCanonicalName() + "{index=" + index + ", editPersonDescriptor="
                 + editPersonDescriptor + "}";
         assertEquals(expected, editCommand.toString());

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -28,9 +28,12 @@ import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Patient;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.PersonType;
+import seedu.address.model.person.Specialist;
 import seedu.address.testutil.EditPatientDescriptorBuilder;
+import seedu.address.testutil.EditSpecialistDescriptorBuilder;
 import seedu.address.testutil.PatientBuilder;
 import seedu.address.testutil.PersonBuilder;
+import seedu.address.testutil.SpecialistBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for EditCommand.
@@ -55,22 +58,24 @@ public class EditCommandTest {
 
     @Test
     public void execute_someFieldsSpecifiedUnfilteredList_success() {
+        model.updateFilteredPersonList(PersonType.SPECIALIST.getSearchPredicate());
         Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
         Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
 
-        PersonBuilder personInList = new PatientBuilder((Patient) lastPerson);
+        PersonBuilder personInList = new SpecialistBuilder((Specialist) lastPerson);
         Person editedPerson = personInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
                 .withTags(VALID_TAG_HUSBAND).build();
 
-        EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder().withName(VALID_NAME_BOB)
+        EditPersonDescriptor descriptor = new EditSpecialistDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_HUSBAND).build();
-        EditCommand editCommand = new EditCommand(indexLastPerson, descriptor, PersonType.PATIENT);
+        EditCommand editCommand = new EditCommand(indexLastPerson, descriptor, PersonType.SPECIALIST);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(lastPerson, editedPerson);
 
+        expectedModel.setPerson(lastPerson, editedPerson);
+        expectedModel.updateFilteredPersonList(PersonType.SPECIALIST.getSearchPredicate());
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
@@ -173,6 +178,9 @@ public class EditCommandTest {
 
         // different descriptor -> returns false
         assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_PERSON, DESC_BOB, PersonType.PATIENT)));
+
+        // different personType -> returns false
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_PERSON, DESC_AMY, PersonType.SPECIALIST)));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -28,12 +28,9 @@ import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Patient;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.PersonType;
-import seedu.address.model.person.Specialist;
 import seedu.address.testutil.EditPatientDescriptorBuilder;
-import seedu.address.testutil.EditSpecialistDescriptorBuilder;
 import seedu.address.testutil.PatientBuilder;
 import seedu.address.testutil.PersonBuilder;
-import seedu.address.testutil.SpecialistBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for EditCommand.

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -46,7 +46,7 @@ public class EditCommandTest {
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
         Patient editedPatient = new PatientBuilder().build();
         EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder(editedPatient).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor, PersonType.PATIENT);
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPatient));
 
@@ -68,7 +68,7 @@ public class EditCommandTest {
 
         EditPersonDescriptor descriptor = new EditSpecialistDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_HUSBAND).build();
-        EditCommand editCommand = new EditCommand(indexLastPerson, descriptor, PersonType.SPECIALIST);
+        EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
@@ -81,7 +81,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPatientDescriptor(), PersonType.PATIENT);
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPatientDescriptor());
         Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
@@ -94,15 +94,15 @@ public class EditCommandTest {
     @Test
     public void execute_filteredList_success() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-
         Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person editedPerson = new PatientBuilder((Patient) personInFilteredList).withName(VALID_NAME_BOB).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
-                new EditPatientDescriptorBuilder().withName(VALID_NAME_BOB).build(), PersonType.PATIENT);
+                new EditPatientDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
@@ -112,7 +112,7 @@ public class EditCommandTest {
     public void execute_duplicatePersonUnfilteredList_failure() {
         Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder((Patient) firstPerson).build();
-        EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor, PersonType.PATIENT);
+        EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
     }
@@ -124,7 +124,7 @@ public class EditCommandTest {
         // edit person in filtered list into a duplicate in address book
         Person personInList = model.getAddressBook().getPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
-                new EditPatientDescriptorBuilder((Patient) personInList).build(), PersonType.PATIENT);
+                new EditPatientDescriptorBuilder((Patient) personInList).build());
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
     }
@@ -133,7 +133,7 @@ public class EditCommandTest {
     public void execute_invalidPersonIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
         EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder().withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor, PersonType.PATIENT);
+        EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
@@ -150,18 +150,18 @@ public class EditCommandTest {
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
         EditCommand editCommand = new EditCommand(outOfBoundIndex,
-                new EditPatientDescriptorBuilder().withName(VALID_NAME_BOB).build(), PersonType.PATIENT);
+                new EditPatientDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
     public void equals() {
-        final EditCommand standardCommand = new EditCommand(INDEX_FIRST_PERSON, DESC_AMY, PersonType.PATIENT);
+        final EditCommand standardCommand = new EditCommand(INDEX_FIRST_PERSON, DESC_AMY);
 
         // same values -> returns true
         EditPersonDescriptor copyDescriptor = new EditPatientDescriptor((EditPatientDescriptor) DESC_AMY);
-        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST_PERSON, copyDescriptor, PersonType.PATIENT);
+        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST_PERSON, copyDescriptor);
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
@@ -174,20 +174,17 @@ public class EditCommandTest {
         assertFalse(standardCommand.equals(new ClearCommand()));
 
         // different index -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_PERSON, DESC_AMY, PersonType.PATIENT)));
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_PERSON, DESC_AMY)));
 
         // different descriptor -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_PERSON, DESC_BOB, PersonType.PATIENT)));
-
-        // different personType -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_PERSON, DESC_AMY, PersonType.SPECIALIST)));
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_PERSON, DESC_BOB)));
     }
 
     @Test
     public void toStringMethod() {
         Index index = Index.fromOneBased(1);
         EditPersonDescriptor editPersonDescriptor = new EditPatientDescriptor();
-        EditCommand editCommand = new EditCommand(index, editPersonDescriptor, PersonType.PATIENT);
+        EditCommand editCommand = new EditCommand(index, editPersonDescriptor);
         String expected = EditCommand.class.getCanonicalName() + "{index=" + index + ", editPersonDescriptor="
                 + editPersonDescriptor + "}";
         assertEquals(expected, editCommand.toString());

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -2,6 +2,8 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.model.person.PersonType.PATIENT;
+import static seedu.address.model.person.PersonType.SPECIALIST;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
@@ -11,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.person.PersonType;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
@@ -28,13 +29,19 @@ public class ListCommandTest {
     }
 
     @Test
-    public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCommand(PersonType.PATIENT), model, ListCommand.PATIENT_MESSAGE_SUCCESS, expectedModel);
+    public void executePatient_listIsNotFiltered_showsSameList() {
+        assertCommandSuccess(new ListCommand(PATIENT), model, ListCommand.PATIENT_MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
-    public void execute_listIsFiltered_showsEverything() {
+    public void executeSpecialist_listIsNotFiltered_showsSameList() {
+        expectedModel.updateFilteredPersonList(SPECIALIST.getSearchPredicate());
+        assertCommandSuccess(new ListCommand(SPECIALIST), model, ListCommand.SPECIALIST_MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void executePatient_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        assertCommandSuccess(new ListCommand(PersonType.PATIENT), model, ListCommand.PATIENT_MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListCommand(PATIENT), model, ListCommand.PATIENT_MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.PersonType;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
@@ -28,12 +29,12 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListCommand(PersonType.PATIENT), model, ListCommand.PATIENT_MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListCommand(PersonType.PATIENT), model, ListCommand.PATIENT_MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -31,8 +31,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SPECIALTY;
-import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
-import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseComplexFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseComplexSuccess;
 import static seedu.address.testutil.TypicalPersons.AMY;
 import static seedu.address.testutil.TypicalPersons.BOB;
 
@@ -58,13 +58,13 @@ public class AddCommandParserTest {
         Person expectedPatient = new PatientBuilder(AMY).withTags(VALID_TAG_FRIEND).build();
 
         // whitespace only preamble
-        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
+        assertParseComplexSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
                 + ADDRESS_DESC_AMY + TAG_DESC_FRIEND, new AddCommand(expectedPatient), PersonType.PATIENT);
 
         // multiple tags - all accepted
         Person expectedPatientMultipleTags = new PatientBuilder(AMY).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
                 .build();
-        assertParseSuccess(parser,
+        assertParseComplexSuccess(parser,
                 NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 new AddCommand(expectedPatientMultipleTags), PersonType.PATIENT);
     }
@@ -73,14 +73,14 @@ public class AddCommandParserTest {
         Person expectedSpecialist = new SpecialistBuilder(BOB).withTags(VALID_TAG_FRIEND).build();
 
         // whitespace only preamble
-        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
+        assertParseComplexSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB + TAG_DESC_FRIEND + SPECIALTY_DESC_BOB, new AddCommand(expectedSpecialist),
                 PersonType.SPECIALIST);
 
         // multiple tags - all accepted
         Person expectedSpecialistMultipleTags = new SpecialistBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
                 .build();
-        assertParseSuccess(parser,
+        assertParseComplexSuccess(parser,
                 NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND
                         + TAG_DESC_FRIEND + SPECIALTY_DESC_BOB,
                 new AddCommand(expectedSpecialistMultipleTags), PersonType.SPECIALIST);
@@ -94,23 +94,23 @@ public class AddCommandParserTest {
         String validExpectedSpecialistString = validExpectedPersonString + SPECIALTY_DESC_BOB;
 
         // multiple names
-        assertParseFailure(parser, NAME_DESC_AMY + validExpectedSpecialistString,
+        assertParseComplexFailure(parser, NAME_DESC_AMY + validExpectedSpecialistString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME), PersonType.SPECIALIST);
 
         // multiple phones
-        assertParseFailure(parser, PHONE_DESC_AMY + validExpectedSpecialistString,
+        assertParseComplexFailure(parser, PHONE_DESC_AMY + validExpectedSpecialistString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE), PersonType.SPECIALIST);
 
         // multiple emails
-        assertParseFailure(parser, EMAIL_DESC_AMY + validExpectedSpecialistString,
+        assertParseComplexFailure(parser, EMAIL_DESC_AMY + validExpectedSpecialistString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL), PersonType.SPECIALIST);
 
         // multiple addresses
-        assertParseFailure(parser, ADDRESS_DESC_AMY + validExpectedSpecialistString,
+        assertParseComplexFailure(parser, ADDRESS_DESC_AMY + validExpectedSpecialistString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS), PersonType.SPECIALIST);
 
         // multiple fields repeated
-        assertParseFailure(parser,
+        assertParseComplexFailure(parser,
                 validExpectedSpecialistString + PHONE_DESC_AMY + EMAIL_DESC_AMY + NAME_DESC_AMY + ADDRESS_DESC_AMY
                         + validExpectedPersonString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_ADDRESS, PREFIX_EMAIL, PREFIX_PHONE),
@@ -119,41 +119,41 @@ public class AddCommandParserTest {
         // invalid value followed by valid value
 
         // invalid name
-        assertParseFailure(parser, INVALID_NAME_DESC + validExpectedSpecialistString,
+        assertParseComplexFailure(parser, INVALID_NAME_DESC + validExpectedSpecialistString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME), PersonType.SPECIALIST);
 
         // invalid email
-        assertParseFailure(parser, INVALID_EMAIL_DESC + validExpectedSpecialistString,
+        assertParseComplexFailure(parser, INVALID_EMAIL_DESC + validExpectedSpecialistString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL), PersonType.SPECIALIST);
 
         // invalid phone
-        assertParseFailure(parser, INVALID_PHONE_DESC + validExpectedSpecialistString,
+        assertParseComplexFailure(parser, INVALID_PHONE_DESC + validExpectedSpecialistString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE), PersonType.SPECIALIST);
 
         // invalid address
-        assertParseFailure(parser, INVALID_ADDRESS_DESC + validExpectedSpecialistString,
+        assertParseComplexFailure(parser, INVALID_ADDRESS_DESC + validExpectedSpecialistString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS), PersonType.SPECIALIST);
 
         // valid value followed by invalid value
 
         // invalid name
-        assertParseFailure(parser, validExpectedSpecialistString + INVALID_NAME_DESC,
+        assertParseComplexFailure(parser, validExpectedSpecialistString + INVALID_NAME_DESC,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME), PersonType.SPECIALIST);
 
         // invalid email
-        assertParseFailure(parser, validExpectedSpecialistString + INVALID_EMAIL_DESC,
+        assertParseComplexFailure(parser, validExpectedSpecialistString + INVALID_EMAIL_DESC,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL), PersonType.SPECIALIST);
 
         // invalid phone
-        assertParseFailure(parser, validExpectedSpecialistString + INVALID_PHONE_DESC,
+        assertParseComplexFailure(parser, validExpectedSpecialistString + INVALID_PHONE_DESC,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE), PersonType.SPECIALIST);
 
         // invalid address
-        assertParseFailure(parser, validExpectedSpecialistString + INVALID_ADDRESS_DESC,
+        assertParseComplexFailure(parser, validExpectedSpecialistString + INVALID_ADDRESS_DESC,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS), PersonType.SPECIALIST);
 
         // invalid specialty
-        assertParseFailure(parser, validExpectedSpecialistString + INVALID_SPECIALTY_DESC,
+        assertParseComplexFailure(parser, validExpectedSpecialistString + INVALID_SPECIALTY_DESC,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_SPECIALTY), PersonType.SPECIALIST);
     }
 
@@ -161,7 +161,7 @@ public class AddCommandParserTest {
     public void parse_optionalFieldsMissing_success() {
         // zero tags
         Person expectedPerson = new PatientBuilder(AMY).withTags().build();
-        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY,
+        assertParseComplexSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY,
                 new AddCommand(expectedPerson), PersonType.PATIENT);
     }
 
@@ -170,60 +170,60 @@ public class AddCommandParserTest {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
 
         // missing name prefix
-        assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
+        assertParseComplexFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
                 expectedMessage, PersonType.PATIENT);
 
         // missing phone prefix
-        assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
+        assertParseComplexFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
                 expectedMessage, PersonType.PATIENT);
 
         // missing email prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_EMAIL_BOB + ADDRESS_DESC_BOB,
+        assertParseComplexFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_EMAIL_BOB + ADDRESS_DESC_BOB,
                 expectedMessage, PersonType.PATIENT);
 
         // missing address prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + VALID_ADDRESS_BOB,
+        assertParseComplexFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + VALID_ADDRESS_BOB,
                 expectedMessage, PersonType.PATIENT);
 
         // all prefixes missing
-        assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_EMAIL_BOB + VALID_ADDRESS_BOB,
+        assertParseComplexFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_EMAIL_BOB + VALID_ADDRESS_BOB,
                 expectedMessage, PersonType.PATIENT);
     }
 
     @Test
     public void parse_invalidValue_failure() {
         // invalid name
-        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+        assertParseComplexFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
                 + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPECIALTY_DESC_BOB,
                 Name.MESSAGE_CONSTRAINTS, PersonType.SPECIALIST);
 
         // invalid phone
-        assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+        assertParseComplexFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
                 + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPECIALTY_DESC_BOB,
                 Phone.MESSAGE_CONSTRAINTS, PersonType.SPECIALIST);
 
         // invalid email
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC + ADDRESS_DESC_BOB
+        assertParseComplexFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC + ADDRESS_DESC_BOB
                 + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPECIALTY_DESC_BOB,
                 Email.MESSAGE_CONSTRAINTS, PersonType.SPECIALIST);
 
         // invalid address
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
+        assertParseComplexFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
                 + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPECIALTY_DESC_BOB,
                 Address.MESSAGE_CONSTRAINTS, PersonType.SPECIALIST);
 
         // invalid tag
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+        assertParseComplexFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
                 + INVALID_TAG_DESC + VALID_TAG_FRIEND + SPECIALTY_DESC_BOB,
                 Tag.MESSAGE_CONSTRAINTS, PersonType.SPECIALIST);
 
         // two invalid values, only first invalid value reported
-        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB
+        assertParseComplexFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB
                         + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC + SPECIALTY_DESC_BOB,
                 Name.MESSAGE_CONSTRAINTS, PersonType.SPECIALIST);
 
         // non-empty preamble
-        assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
+        assertParseComplexFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPECIALTY_DESC_BOB,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE), PersonType.SPECIALIST);
     }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -63,14 +63,14 @@ public class AddressBookParserTest {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " " + CliSyntax.SPECIALIST_TAG
                         + " " + INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON, PersonType.SPECIALIST), command);
+        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
     }
     @Test
     public void parseCommand_delete_specialist() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " " + CliSyntax.SPECIALIST_TAG
                         + " " + INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON, PersonType.SPECIALIST), command);
+        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -61,15 +61,13 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_delete_patient() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + CliSyntax.SPECIALIST_TAG
-                        + " " + INDEX_FIRST_PERSON.getOneBased());
+                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
     }
     @Test
     public void parseCommand_delete_specialist() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + CliSyntax.SPECIALIST_TAG
-                        + " " + INDEX_FIRST_PERSON.getOneBased());
+                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
     }
 
@@ -80,7 +78,7 @@ public class AddressBookParserTest {
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD
                 + " " + CliSyntax.PATIENT_TAG + " "
                 + INDEX_FIRST_PERSON.getOneBased() + " " + PatientUtil.getEditPatientDescriptorDetails(descriptor));
-        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor, PersonType.PATIENT), command);
+        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
     }
 
     @Test
@@ -91,7 +89,7 @@ public class AddressBookParserTest {
                 + " " + CliSyntax.SPECIALIST_TAG + " "
                 + INDEX_FIRST_PERSON.getOneBased()
                 + " " + SpecialistUtil.getEditSpecialistDescriptorDetails(descriptor));
-        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor, PersonType.SPECIALIST), command);
+        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -80,7 +80,7 @@ public class AddressBookParserTest {
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD
                 + " " + CliSyntax.PATIENT_TAG + " "
                 + INDEX_FIRST_PERSON.getOneBased() + " " + PatientUtil.getEditPatientDescriptorDetails(descriptor));
-        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
+        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor, PersonType.PATIENT), command);
     }
 
     @Test
@@ -91,7 +91,7 @@ public class AddressBookParserTest {
                 + " " + CliSyntax.SPECIALIST_TAG + " "
                 + INDEX_FIRST_PERSON.getOneBased()
                 + " " + SpecialistUtil.getEditSpecialistDescriptorDetails(descriptor));
-        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
+        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor, PersonType.SPECIALIST), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
+++ b/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
@@ -12,13 +12,13 @@ import seedu.address.model.person.PersonType;
 public class CommandParserTestUtil {
 
     /**
-     * Asserts that the parsing of {@code userInput} by {@code parser} is successful and the command created
+     * Asserts that the parsing of {@code userInput} by {@code parserComplex} is successful and the command created
      * equals to {@code expectedCommand}.
      */
-    public static void assertParseSuccess(Parser<? extends Command> parser, String userInput,
-            Command expectedCommand, PersonType personType) {
+    public static void assertParseComplexSuccess(ParserComplex<? extends Command> parserComplex, String userInput,
+                                                 Command expectedCommand, PersonType personType) {
         try {
-            Command command = parser.parse(personType, userInput);
+            Command command = parserComplex.parse(personType, userInput);
             assertEquals(expectedCommand, command);
         } catch (ParseException pe) {
             throw new IllegalArgumentException("Invalid userInput.", pe);
@@ -26,13 +26,42 @@ public class CommandParserTestUtil {
     }
 
     /**
-     * Asserts that the parsing of {@code userInput} by {@code parser} is unsuccessful and the error message
+     * Asserts that the parsing of {@code userInput} by {@code parserComplex} is unsuccessful and the error message
      * equals to {@code expectedMessage}.
      */
-    public static void assertParseFailure(Parser<? extends Command> parser, String userInput, String expectedMessage,
-                                          PersonType personType) {
+    public static void assertParseComplexFailure(ParserComplex<? extends Command> parserComplex,
+                                                 String userInput, String expectedMessage,
+                                                 PersonType personType) {
         try {
-            parser.parse(personType, userInput);
+            parserComplex.parse(personType, userInput);
+            throw new AssertionError("The expected ParseException was not thrown.");
+        } catch (ParseException pe) {
+            assertEquals(expectedMessage, pe.getMessage());
+        }
+    }
+
+    /**
+     * Asserts that the parsing of {@code userInput} by {@code parserComplex} is successful and the command created
+     * equals to {@code expectedCommand}.
+     */
+    public static void assertParseBasicSuccess(ParserBasic<? extends Command> parserBasic, String userInput,
+                                                 Command expectedCommand) {
+        try {
+            Command command = parserBasic.parse(userInput);
+            assertEquals(expectedCommand, command);
+        } catch (ParseException pe) {
+            throw new IllegalArgumentException("Invalid userInput.", pe);
+        }
+    }
+
+    /**
+     * Asserts that the parsing of {@code userInput} by {@code parserComplex} is unsuccessful and the error message
+     * equals to {@code expectedMessage}.
+     */
+    public static void assertParseBasicFailure(ParserBasic<? extends Command> parserBasic, String userInput,
+                                               String expectedMessage) {
+        try {
+            parserBasic.parse(userInput);
             throw new AssertionError("The expected ParseException was not thrown.");
         } catch (ParseException pe) {
             assertEquals(expectedMessage, pe.getMessage());

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -23,7 +23,7 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON, PersonType.PATIENT),
+        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON),
                 PersonType.PATIENT);
     }
 

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,14 +1,13 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
-import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseBasicFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseBasicSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.model.person.PersonType;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
@@ -23,13 +22,12 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON),
-                PersonType.PATIENT);
+        assertParseBasicSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                DeleteCommand.MESSAGE_USAGE), PersonType.PATIENT);
+        assertParseBasicFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -126,7 +126,7 @@ public class EditCommandParserTest {
                 .withSpecialty(VALID_SPECIALTY_DERMATOLOGY).withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
                 .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor, PersonType.SPECIALIST);
 
         assertParseSuccess(parser, userInput, expectedCommand, PersonType.SPECIALIST);
     }
@@ -138,7 +138,7 @@ public class EditCommandParserTest {
 
         EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder().withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_AMY).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor, PersonType.PATIENT);
 
         assertParseSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
     }
@@ -149,31 +149,31 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_THIRD_PERSON;
         String userInput = targetIndex.getOneBased() + NAME_DESC_AMY;
         EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder().withName(VALID_NAME_AMY).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor, PersonType.PATIENT);
         assertParseSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
 
         // phone
         userInput = targetIndex.getOneBased() + PHONE_DESC_AMY;
         descriptor = new EditPatientDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditCommand(targetIndex, descriptor, PersonType.PATIENT);
         assertParseSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
 
         // email
         userInput = targetIndex.getOneBased() + EMAIL_DESC_AMY;
         descriptor = new EditPatientDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditCommand(targetIndex, descriptor, PersonType.PATIENT);
         assertParseSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
 
         // address
         userInput = targetIndex.getOneBased() + ADDRESS_DESC_AMY;
         descriptor = new EditPatientDescriptorBuilder().withAddress(VALID_ADDRESS_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditCommand(targetIndex, descriptor, PersonType.PATIENT);
         assertParseSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
 
         // tags
         userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND;
         descriptor = new EditPatientDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditCommand(targetIndex, descriptor, PersonType.PATIENT);
         assertParseSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
     }
 
@@ -219,7 +219,7 @@ public class EditCommandParserTest {
         String userInput = targetIndex.getOneBased() + TAG_EMPTY;
 
         EditPersonDescriptor descriptor = new EditSpecialistDescriptorBuilder().withTags().build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor, PersonType.SPECIALIST);
 
         assertParseSuccess(parser, userInput, expectedCommand, PersonType.SPECIALIST);
     }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -28,8 +28,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
-import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseComplexFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseComplexSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
@@ -61,58 +61,59 @@ public class EditCommandParserTest {
     @Test
     public void parse_missingParts_failure() {
         // no index specified
-        assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT, PersonType.SPECIALIST);
+        assertParseComplexFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT, PersonType.SPECIALIST);
 
         // no field specified
-        assertParseFailure(parser, "1", EditCommand.MESSAGE_NOT_EDITED, PersonType.SPECIALIST);
+        assertParseComplexFailure(parser, "1", EditCommand.MESSAGE_NOT_EDITED, PersonType.SPECIALIST);
 
         // no index and no field specified
-        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT, PersonType.SPECIALIST);
+        assertParseComplexFailure(parser, "", MESSAGE_INVALID_FORMAT, PersonType.SPECIALIST);
     }
 
     @Test
     public void parse_invalidPreamble_failure() {
         // negative index
-        assertParseFailure(parser, "-5" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT, PersonType.SPECIALIST);
+        assertParseComplexFailure(parser, "-5" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT, PersonType.SPECIALIST);
 
         // zero index
-        assertParseFailure(parser, "0" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT, PersonType.SPECIALIST);
+        assertParseComplexFailure(parser, "0" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT, PersonType.SPECIALIST);
 
         // invalid arguments being parsed as preamble
-        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT, PersonType.SPECIALIST);
+        assertParseComplexFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT, PersonType.SPECIALIST);
 
         // invalid prefix being parsed as preamble
-        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT, PersonType.SPECIALIST);
+        assertParseComplexFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT, PersonType.SPECIALIST);
     }
 
     @Test
     public void parse_invalidValue_failure() {
-        assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS,
+        assertParseComplexFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS,
                 PersonType.PATIENT); // invalid name
-        assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS,
+        assertParseComplexFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS,
                 PersonType.PATIENT); // invalid phone
-        assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS,
+        assertParseComplexFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS,
                 PersonType.PATIENT); // invalid email
-        assertParseFailure(parser, "1" + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS,
+        assertParseComplexFailure(parser, "1" + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS,
                 PersonType.PATIENT); // invalid address
-        assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS,
+        assertParseComplexFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS,
                 PersonType.PATIENT); // invalid tag
 
         // invalid phone followed by valid email
-        assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS,
+        assertParseComplexFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS,
                 PersonType.PATIENT);
 
         // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Person} being edited,
         // parsing it together with a valid tag results in error
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY,
+        assertParseComplexFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY,
                 Tag.MESSAGE_CONSTRAINTS, PersonType.PATIENT);
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND,
+        assertParseComplexFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND,
                 Tag.MESSAGE_CONSTRAINTS, PersonType.PATIENT);
-        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND,
+        assertParseComplexFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND,
                 Tag.MESSAGE_CONSTRAINTS, PersonType.PATIENT);
 
         // multiple invalid values, but only the first invalid value is captured
-        assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_ADDRESS_AMY + VALID_PHONE_AMY,
+        assertParseComplexFailure(parser,
+                "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_ADDRESS_AMY + VALID_PHONE_AMY,
                 Name.MESSAGE_CONSTRAINTS, PersonType.PATIENT);
     }
 
@@ -126,9 +127,9 @@ public class EditCommandParserTest {
                 .withSpecialty(VALID_SPECIALTY_DERMATOLOGY).withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
                 .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor, PersonType.SPECIALIST);
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
-        assertParseSuccess(parser, userInput, expectedCommand, PersonType.SPECIALIST);
+        assertParseComplexSuccess(parser, userInput, expectedCommand, PersonType.SPECIALIST);
     }
 
     @Test
@@ -138,9 +139,9 @@ public class EditCommandParserTest {
 
         EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder().withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_AMY).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor, PersonType.PATIENT);
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
-        assertParseSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
+        assertParseComplexSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
     }
 
     @Test
@@ -149,32 +150,32 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_THIRD_PERSON;
         String userInput = targetIndex.getOneBased() + NAME_DESC_AMY;
         EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder().withName(VALID_NAME_AMY).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor, PersonType.PATIENT);
-        assertParseSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        assertParseComplexSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
 
         // phone
         userInput = targetIndex.getOneBased() + PHONE_DESC_AMY;
         descriptor = new EditPatientDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor, PersonType.PATIENT);
-        assertParseSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
+        expectedCommand = new EditCommand(targetIndex, descriptor);
+        assertParseComplexSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
 
         // email
         userInput = targetIndex.getOneBased() + EMAIL_DESC_AMY;
         descriptor = new EditPatientDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor, PersonType.PATIENT);
-        assertParseSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
+        expectedCommand = new EditCommand(targetIndex, descriptor);
+        assertParseComplexSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
 
         // address
         userInput = targetIndex.getOneBased() + ADDRESS_DESC_AMY;
         descriptor = new EditPatientDescriptorBuilder().withAddress(VALID_ADDRESS_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor, PersonType.PATIENT);
-        assertParseSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
+        expectedCommand = new EditCommand(targetIndex, descriptor);
+        assertParseComplexSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
 
         // tags
         userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND;
         descriptor = new EditPatientDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor, PersonType.PATIENT);
-        assertParseSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
+        expectedCommand = new EditCommand(targetIndex, descriptor);
+        assertParseComplexSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
     }
 
     @Test
@@ -186,13 +187,13 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_FIRST_PERSON;
         String userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + PHONE_DESC_BOB;
 
-        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE),
+        assertParseComplexFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE),
                 PersonType.SPECIALIST);
 
         // invalid followed by valid
         userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + INVALID_PHONE_DESC;
 
-        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE),
+        assertParseComplexFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE),
                 PersonType.SPECIALIST);
 
         // mulltiple valid fields repeated
@@ -200,7 +201,7 @@ public class EditCommandParserTest {
                 + TAG_DESC_FRIEND + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
                 + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;
 
-        assertParseFailure(parser, userInput,
+        assertParseComplexFailure(parser, userInput,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS),
                 PersonType.SPECIALIST);
 
@@ -208,7 +209,7 @@ public class EditCommandParserTest {
         userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC
                 + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC;
 
-        assertParseFailure(parser, userInput,
+        assertParseComplexFailure(parser, userInput,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS),
                 PersonType.SPECIALIST);
     }
@@ -219,8 +220,8 @@ public class EditCommandParserTest {
         String userInput = targetIndex.getOneBased() + TAG_EMPTY;
 
         EditPersonDescriptor descriptor = new EditSpecialistDescriptorBuilder().withTags().build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor, PersonType.SPECIALIST);
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
-        assertParseSuccess(parser, userInput, expectedCommand, PersonType.SPECIALIST);
+        assertParseComplexSuccess(parser, userInput, expectedCommand, PersonType.SPECIALIST);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -1,8 +1,8 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
-import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseComplexFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseComplexSuccess;
 
 import java.util.Arrays;
 
@@ -18,7 +18,7 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        assertParseComplexFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 FindCommand.MESSAGE_USAGE), PersonType.PATIENT);
     }
 
@@ -27,10 +27,10 @@ public class FindCommandParserTest {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
                 new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")), PersonType.PATIENT);
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand, PersonType.PATIENT);
+        assertParseComplexSuccess(parser, "Alice Bob", expectedFindCommand, PersonType.PATIENT);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand, PersonType.PATIENT);
+        assertParseComplexSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand, PersonType.PATIENT);
     }
 
 }


### PR DESCRIPTION
- Updated the ListCommand to only show either patients or specialists at once. 
- Added the patient and specialist predicates to the PersonType enum as they could be useful for future command implementations (like FindCommand).
- Removed PersonType requirement for DeleteCommand as it does not make sense when considering the user experience.
  - It is confusing if users can delete patients while viewing a specialists.

 Resolves #61 , resolves #22 , resolves #53 .