### PR TITLE
Fix Find Command Invalid Argument Parsing

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -108,6 +108,7 @@ with all attributes containing any of the corresponding keywords in the command.
 
 Format: `find -PERSON_TYPE [PREFIX/KEYWORDS]`
 
+* All prefixes are optional. Hence, calling `find -PERSON_TYPE` (without any prefixes) will result in all person of the specified type being listed
 * The search is case-insensitive. e.g `hans` will match `Hans`
 * The order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`
 * Only full words will be matched e.g. `Han` will not match `Hans`

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -39,16 +39,6 @@ public class FindCommandParser implements ParserComplex<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(PersonType personType, String args) throws ParseException {
-        if (args.isBlank()) {
-            if (personType.equals(PersonType.PATIENT)) {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                        FindCommand.MESSAGE_USAGE_PATIENT));
-            }
-            if (personType.equals(PersonType.SPECIALIST)) {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                        FindCommand.MESSAGE_USAGE_SPECIALIST));
-            }
-        }
         if (personType.equals(PersonType.PATIENT)) {
             return parsePatient(args);
         } else if (personType.equals(PersonType.SPECIALIST)) {
@@ -62,6 +52,11 @@ public class FindCommandParser implements ParserComplex<FindCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                         PREFIX_TAG, PREFIX_AGE, PREFIX_MEDICALHISTORY);
+
+        if (!argMultimap.getPreamble().isBlank() && !args.isBlank()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    FindCommand.MESSAGE_USAGE_PATIENT));
+        }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                 PREFIX_AGE, PREFIX_MEDICALHISTORY);
@@ -84,6 +79,11 @@ public class FindCommandParser implements ParserComplex<FindCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_LOCATION,
                         PREFIX_TAG, PREFIX_SPECIALTY);
+
+        if (!argMultimap.getPreamble().isBlank() && !args.isBlank()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    FindCommand.MESSAGE_USAGE_SPECIALIST));
+        }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                 PREFIX_LOCATION, PREFIX_SPECIALTY);

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -33,10 +33,10 @@ public class FindCommandParserTest {
     private FindCommandParser parser = new FindCommandParser();
 
     @Test
-    public void parse_emptyArg_throwsParseException() {
-        assertParseComplexFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+    public void parse_invalidArg_throwsParseException() {
+        assertParseComplexFailure(parser, " invalid input", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 FindCommand.MESSAGE_USAGE_PATIENT), PersonType.PATIENT);
-        assertParseComplexFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        assertParseComplexFailure(parser, "  invalid input", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 FindCommand.MESSAGE_USAGE_SPECIALIST), PersonType.SPECIALIST);
     }
 

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -33,10 +33,18 @@ public class FindCommandParserTest {
     private FindCommandParser parser = new FindCommandParser();
 
     @Test
-    public void parse_invalidArg_throwsParseException() {
+    public void parse_invalidPreambleOnly_throwsParseException() {
         assertParseComplexFailure(parser, " invalid input", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 FindCommand.MESSAGE_USAGE_PATIENT), PersonType.PATIENT);
         assertParseComplexFailure(parser, "  invalid input", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FindCommand.MESSAGE_USAGE_SPECIALIST), PersonType.SPECIALIST);
+    }
+
+    @Test
+    public void parse_invalidPreambleValidPrefix_throwsParseException() {
+        assertParseComplexFailure(parser, " invalid input n/Alex", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FindCommand.MESSAGE_USAGE_PATIENT), PersonType.PATIENT);
+        assertParseComplexFailure(parser, "  invalid input p/98736621", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 FindCommand.MESSAGE_USAGE_SPECIALIST), PersonType.SPECIALIST);
     }
 


### PR DESCRIPTION
Resolves #78.
# Notes on Expected Behavior:
- `find` should return an error message
- `find -pa` or `find -sp` should list down all patients or specialists respectively
- `find -pa randomletters` should return an error message
- `find -sp randomletters n/Alex`  should return an error message