### PR TITLE
Improve find command flexibility

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -108,18 +108,18 @@ with all attributes containing any of the corresponding keywords in the command.
 
 Format: `find -PERSON_TYPE [PREFIX/KEYWORDS]`
 
-* All prefixes are optional. Hence, calling `find -PERSON_TYPE` (without any prefixes) will result in all person of the specified type being listed
+* All prefixes are optional. Hence, calling `find -PERSON_TYPE` (without any prefixes) will result in all person of the specified type being listed.
 * The search is case-insensitive.
   * e.g `hans` will match `Hans`
 * The order of the keywords does not matter. 
   * e.g. `Hans Bo` will match `Bo Hans`
 * There are different behaviours regarding the searching of different parameters:
-  * For `NAME`, `EMAIL`, `LOCATION` and `PHONE`, even substrings will be matched 
+  * For `NAME`, `MEDICAL_HISTORY`, `SPECIALISATION`, `EMAIL`, `LOCATION` and `PHONE`, even substrings will be matched. 
     * e.g. `ha` will match `Hans`
-  * For `AGE`, `MEDICAL_HISTORY`, `SPECIALISATION` and `TAGS` only full words will be matched 
-    * e.g. `Ane` will not match `Anemia`
-* Persons matching at least one keyword will be returned (i.e. `OR` search)
-  * The keywords will be separated out by whitespaces e.g. `hans bo` is akin to searching for `hans` and `bo` simultaneously
+  * For `AGE` and `TAGS` only full words will be matched. 
+    * e.g. `1` will not match `18`
+* Persons matching at least one keyword will be returned (i.e. `OR` search).
+  * The keywords will be separated out by whitespaces e.g. `hans bo` is akin to searching for `hans` and `bo` simultaneously.
     * e.g. `Hans Bo` will return `Hans Gruber`, `Bo Yang`
 
 Examples:

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -78,12 +78,12 @@ Format: `help`
 
 Adds a patient or specialist to the address book.
 
-Format (for patients): `add -pa n/NAME p/PHONE_NUMBER a/AGE [m/MEDICAL_HISTORY]...​`<br>
+Format (for patients): `add -pa n/NAME e/EMAIL p/PHONE_NUMBER a/AGE [m/MEDICAL_HISTORY]...​`<br>
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
 A patient can have any number of medical histories (including 0)
 </div>
 
-Format (for specialists): `add -sp n/NAME p/PHONE_NUMBER s/SPECIALISATION l/LOCATION`
+Format (for specialists): `add -sp n/NAME e/EMAIL p/PHONE_NUMBER s/SPECIALISATION l/LOCATION`
 
 
 Examples:
@@ -109,16 +109,23 @@ with all attributes containing any of the corresponding keywords in the command.
 Format: `find -PERSON_TYPE [PREFIX/KEYWORDS]`
 
 * All prefixes are optional. Hence, calling `find -PERSON_TYPE` (without any prefixes) will result in all person of the specified type being listed
-* The search is case-insensitive. e.g `hans` will match `Hans`
-* The order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`
-* Only full words will be matched e.g. `Han` will not match `Hans`
-* Persons matching at least one keyword will be returned (i.e. `OR` search).
-  e.g. `Hans Bo` will return `Hans Gruber`, `Bo Yang`
+* The search is case-insensitive.
+  * e.g `hans` will match `Hans`
+* The order of the keywords does not matter. 
+  * e.g. `Hans Bo` will match `Bo Hans`
+* There are different behaviours regarding the searching of different parameters:
+  * For `NAME`, `EMAIL`, `LOCATION` and `PHONE`, even substrings will be matched 
+    * e.g. `ha` will match `Hans`
+  * For `AGE`, `MEDICAL_HISTORY`, `SPECIALISATION` and `TAGS` only full words will be matched 
+    * e.g. `Ane` will not match `Anemia`
+* Persons matching at least one keyword will be returned (i.e. `OR` search)
+  * The keywords will be separated out by whitespaces e.g. `hans bo` is akin to searching for `hans` and `bo` simultaneously
+    * e.g. `Hans Bo` will return `Hans Gruber`, `Bo Yang`
 
 Examples:
-* `find -pa n/John` returns the patient `john` and the patient `John Doe`
+* `find -pa n/John` returns the patient `Johnny Depp` and the patient `John Doe`
 * `find -sp n/alex david` returns the specialists `Alex Yeoh` and `David Li` 
-* `find -sp n/Alex s/Orthopaedic` returns any specialists with the name `Alex` who has the `Orthopaedic` specialty
+* `find -sp n/Alex s/Orthopaedic` returns any specialists names including the string `Alex` who has the `Orthopaedic` specialty
 <br>
 
 ### Deleting a patient or specialist : `delete`
@@ -182,8 +189,8 @@ If your changes to the data file makes its format invalid, DoConnek Pro will dis
 
 Action | Format, Examples
 --------|------------------
-**Add (patient)** | `add -pa n/NAME p/PHONE_NUMBER a/AGE [m/MEDICAL_HISTORY]...` <br> e.g., `add -pa n/John p/12345678 a/21 m/Osteoporosis m/Rheumatoid arthritis`
-**Add (specialist)** | `add -sp n/NAME p/PHONE_NUMBER s/SPECIALISATION l/LOCATION` <br> e.g., `add -sp n/Jane p/73331515 s/Dermatologist l/Ang Mo Kio`
+**Add (patient)** | `add -pa n/NAME e/EMAIL p/PHONE_NUMBER a/AGE [m/MEDICAL_HISTORY]...` <br> e.g., `add -pa n/John e/johnjohn@example.com p/12345678 a/21 m/Osteoporosis m/Rheumatoid arthritis`
+**Add (specialist)** | `add -sp n/NAME e/EMAIL p/PHONE_NUMBER s/SPECIALISATION l/LOCATION` <br> e.g., `add -sp n/Jane e/janejane@example.com p/73331515 s/Dermatologist l/Ang Mo Kio`
 **Clear** | `clear`
 **Delete** | `delete INDEX`<br> e.g., `delete 3`
 **Find** | `find -PERSON_TYPE KEYWORD [MORE_KEYWORDS]`<br> e.g., `find -pa n/James Jake p/73281193`

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -39,6 +39,31 @@ public class StringUtil {
     }
 
     /**
+     * Returns true if the words in {@code sentence} contains the {@code substring}.
+     *   Ignores case and a full word match is not required.
+     *   <br>examples:<pre>
+     *       wordsContainSubstringIgnoreCase("ABc def", "abc") == true
+     *       wordsContainSubstringIgnoreCase("ABc def", "De") == true
+     *       wordsContainSubstringIgnoreCase("ABc def", "c de") == false //only searches for substrings within words
+     *       </pre>
+     * @param sentence cannot be null
+     * @param substring cannot be null, cannot be empty
+     */
+    public static boolean wordsContainSubstringIgnoreCase(String sentence, String substring) {
+        requireNonNull(sentence);
+        requireNonNull(substring);
+
+        String preppedWord = substring.trim();
+        checkArgument(!preppedWord.isEmpty(), "Substring parameter cannot be empty");
+
+        String preppedSentence = sentence;
+        String[] wordsInPreppedSentence = preppedSentence.split("\\s+");
+
+        return Arrays.stream(wordsInPreppedSentence)
+                .anyMatch(sentenceWord -> sentenceWord.toLowerCase().contains(preppedWord.toLowerCase()));
+    }
+
+    /**
      * Returns a detailed message of the t, including the stack trace.
      */
     public static String getDetails(Throwable t) {

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -33,14 +33,12 @@ public class AddCommand extends Command {
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
-            + PREFIX_LOCATION + "LOCATION "
             + "[" + PREFIX_TAG + "TAG]... ";
 
     private static final String PERSON_EXAMPLE =
             PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
-            + PREFIX_LOCATION + "311, Clementi Ave 2, #02-25 "
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney ";
 
@@ -61,10 +59,12 @@ public class AddCommand extends Command {
             + SPECIALIST_TAG
             + ": Adds a specialist to the address book. \n"
             + MESSAGE_USAGE_GENERAL
+            + PREFIX_LOCATION + "LOCATION "
             + PREFIX_SPECIALTY + "SPECIALTY \n"
             + "Example: " + COMMAND_WORD + " "
             + SPECIALIST_TAG + " "
             + PERSON_EXAMPLE
+            + PREFIX_LOCATION + "311, Clementi Ave 2, #02-25 "
             + PREFIX_SPECIALTY + "Physiotherapist ";
 
     private final Person toAdd;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -51,14 +51,12 @@ public class EditCommand extends Command {
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
-            + PREFIX_LOCATION + "LOCATION "
             + "[" + PREFIX_TAG + "TAG]... ";
 
     private static final String PERSON_EXAMPLE =
             PREFIX_NAME + "John Doe "
                     + PREFIX_PHONE + "98765432 "
                     + PREFIX_EMAIL + "johnd@example.com "
-                    + PREFIX_LOCATION + "311, Clementi Ave 2, #02-25 "
                     + PREFIX_TAG + "friends "
                     + PREFIX_TAG + "owesMoney ";
 
@@ -79,10 +77,12 @@ public class EditCommand extends Command {
             + SPECIALIST_TAG
             + ": edit a specialist in the address book. \n"
             + MESSAGE_USAGE_GENERAL
+            + PREFIX_LOCATION + "LOCATION "
             + PREFIX_SPECIALTY + "SPECIALTY \n"
             + "Example: " + COMMAND_WORD + " "
             + SPECIALIST_TAG + " "
             + PERSON_EXAMPLE
+            + PREFIX_LOCATION + "311, Clementi Ave 2, #02-25 "
             + PREFIX_SPECIALTY + "Physiotherapist ";
 
     private final Index index;

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -30,14 +30,12 @@ public class FindCommand extends Command {
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
-            + PREFIX_LOCATION + "LOCATION "
             + "[" + PREFIX_TAG + "TAG]... ";
 
     private static final String PERSON_EXAMPLE =
             PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
-            + PREFIX_LOCATION + "311, Clementi Ave 2, #02-25 "
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney ";
 
@@ -60,10 +58,12 @@ public class FindCommand extends Command {
             + ": Finds all Specialists whose attributes contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers. \n"
             + MESSAGE_USAGE_GENERAL
+            + PREFIX_LOCATION + "LOCATION "
             + PREFIX_SPECIALTY + "SPECIALTY \n"
             + "Example: " + COMMAND_WORD + " "
             + SPECIALIST_TAG + " "
             + PERSON_EXAMPLE
+            + PREFIX_LOCATION + "311, Clementi Ave 2, #02-25 "
             + PREFIX_SPECIALTY + "Physiotherapist ";
 
 

--- a/src/main/java/seedu/address/model/person/predicates/EmailContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/EmailContainsKeywordsPredicate.java
@@ -21,7 +21,7 @@ public class EmailContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getEmail().value, keyword));
+                .anyMatch(keyword -> StringUtil.wordsContainSubstringIgnoreCase(person.getEmail().value, keyword));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/predicates/LocationContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/LocationContainsKeywordsPredicate.java
@@ -28,7 +28,7 @@ public class LocationContainsKeywordsPredicate implements Predicate<Person> {
         // It is safe to type cast Person to Specialist due to the guard clause above.
         Specialist specialist = (Specialist) person;
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(specialist.getLocation().value, keyword));
+                .anyMatch(keyword -> StringUtil.wordsContainSubstringIgnoreCase(specialist.getLocation().value, keyword));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/predicates/LocationContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/LocationContainsKeywordsPredicate.java
@@ -28,7 +28,8 @@ public class LocationContainsKeywordsPredicate implements Predicate<Person> {
         // It is safe to type cast Person to Specialist due to the guard clause above.
         Specialist specialist = (Specialist) person;
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.wordsContainSubstringIgnoreCase(specialist.getLocation().value, keyword));
+                .anyMatch(keyword ->
+                        StringUtil.wordsContainSubstringIgnoreCase(specialist.getLocation().value, keyword));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/predicates/MedHistoryContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/MedHistoryContainsKeywordsPredicate.java
@@ -31,7 +31,7 @@ public class MedHistoryContainsKeywordsPredicate implements Predicate<Person> {
                 .stream()
                 .map(medicalHistory -> keywords
                         .stream()
-                        .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(medicalHistory.value, keyword)))
+                        .anyMatch(keyword -> StringUtil.wordsContainSubstringIgnoreCase(medicalHistory.value, keyword)))
                 .reduce(false, (x, y) -> x || y);
     }
     @Override

--- a/src/main/java/seedu/address/model/person/predicates/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/NameContainsKeywordsPredicate.java
@@ -20,7 +20,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+                .anyMatch(keyword -> StringUtil.wordsContainSubstringIgnoreCase(person.getName().fullName, keyword));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/predicates/PhoneContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/PhoneContainsKeywordsPredicate.java
@@ -20,7 +20,7 @@ public class PhoneContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getPhone().value, keyword));
+                .anyMatch(keyword -> StringUtil.wordsContainSubstringIgnoreCase(person.getPhone().value, keyword));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/predicates/SpecialtyContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/SpecialtyContainsKeywordsPredicate.java
@@ -29,7 +29,8 @@ public class SpecialtyContainsKeywordsPredicate implements Predicate<Person> {
         Specialist specialist = (Specialist) person;
 
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(specialist.getSpecialty().value, keyword));
+                .anyMatch(keyword ->
+                        StringUtil.wordsContainSubstringIgnoreCase(specialist.getSpecialty().value, keyword));
     }
 
     @Override

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -123,6 +123,77 @@ public class StringUtilTest {
         assertTrue(StringUtil.containsWordIgnoreCase("AAA bBb ccc  bbb", "bbB"));
     }
 
+    //---------------- Tests for wordsContainSubstringIgnoreCase --------------------------------------
+
+    /*
+     * Invalid equivalence partitions for word: null, empty
+     * Invalid equivalence partitions for sentence: null
+     * The three test cases below test one invalid input at a time.
+     */
+    @Test
+    public void wordsContainSubstringIgnoreCase_nullWord_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> StringUtil.wordsContainSubstringIgnoreCase("typical sentence", null));
+    }
+
+    @Test
+    public void wordsContainSubstringIgnoreCase_emptyWord_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, "Word parameter cannot be empty", ()
+                -> StringUtil.wordsContainSubstringIgnoreCase("typical sentence", "  "));
+    }
+
+    @Test
+    public void wordsContainSubstringIgnoreCase_nullSentence_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> StringUtil.wordsContainSubstringIgnoreCase(null, "abc"));
+    }
+
+    /*
+     * Valid equivalence partitions for substring:
+     *   - any substring
+     *   - substrings containing symbols/numbers
+     *   - word with leading/trailing spaces
+     *
+     * Valid equivalence partitions for sentence:
+     *   - empty string
+     *   - one word
+     *   - multiple words
+     *   - sentence with extra spaces
+     *
+     * Possible scenarios returning true:
+     *   - matches first word in sentence
+     *   - last word in sentence
+     *   - middle word in sentence
+     *   - matches multiple words
+     *   - matches part of a word
+     *
+     * Possible scenarios returning false:
+     *   - query word matches part of a sentence word
+     *   - sentence word matches part of the query word
+     *
+     * The test method below tries to verify all above with a reasonably low number of test cases.
+     */
+
+    @Test
+    public void wordsContainSubstringIgnoreCase_validInputs_correctResult() {
+
+        // Empty sentence
+        assertFalse(StringUtil.wordsContainSubstringIgnoreCase("", "abc")); // Boundary case
+        assertFalse(StringUtil.wordsContainSubstringIgnoreCase("    ", "123"));
+
+        // Matches a partial word in the sentence
+        assertTrue(StringUtil.wordsContainSubstringIgnoreCase("aaa bbb ccc", "bb")); // Sentence word bigger than query word
+        assertFalse(StringUtil.wordsContainSubstringIgnoreCase("aaa bbb ccc", "bbbb")); // Query word bigger than sentence word
+
+        // Matches partial word in the sentence, different upper/lower case letters
+        assertTrue(StringUtil.wordsContainSubstringIgnoreCase("aaa bBb ccc", "Bb")); // First word (boundary case)
+        assertTrue(StringUtil.wordsContainSubstringIgnoreCase("aaa bBb ccc@1", "C@1")); // Last word (boundary case)
+        assertTrue(StringUtil.wordsContainSubstringIgnoreCase("  AAA   bBb   ccc  ", "aa")); // Sentence has extra spaces
+        assertTrue(StringUtil.wordsContainSubstringIgnoreCase("Aaa", "aa")); // Only one word in sentence (boundary case)
+        assertTrue(StringUtil.wordsContainSubstringIgnoreCase("aaa bbb ccc", "  cc  ")); // Leading/trailing spaces
+
+        // Matches multiple words in sentence
+        assertTrue(StringUtil.wordsContainSubstringIgnoreCase("AAA bBb ccc  bbb", "bB"));
+    }
+
     //---------------- Tests for getDetails --------------------------------------
 
     /*

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -56,13 +56,14 @@ public class StringUtilTest {
 
     @Test
     public void containsWordIgnoreCase_nullWord_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> StringUtil.containsWordIgnoreCase("typical sentence", null));
+        assertThrows(NullPointerException.class, () ->
+                StringUtil.containsWordIgnoreCase("typical sentence", null));
     }
 
     @Test
     public void containsWordIgnoreCase_emptyWord_throwsIllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class, "Word parameter cannot be empty", ()
-            -> StringUtil.containsWordIgnoreCase("typical sentence", "  "));
+        assertThrows(IllegalArgumentException.class, "Word parameter cannot be empty", () ->
+                StringUtil.containsWordIgnoreCase("typical sentence", "  "));
     }
 
     @Test
@@ -132,18 +133,20 @@ public class StringUtilTest {
      */
     @Test
     public void wordsContainSubstringIgnoreCase_nullWord_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> StringUtil.wordsContainSubstringIgnoreCase("typical sentence", null));
+        assertThrows(NullPointerException.class, () ->
+                StringUtil.wordsContainSubstringIgnoreCase("typical sentence", null));
     }
 
     @Test
     public void wordsContainSubstringIgnoreCase_emptyWord_throwsIllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class, "Word parameter cannot be empty", ()
-                -> StringUtil.wordsContainSubstringIgnoreCase("typical sentence", "  "));
+        assertThrows(IllegalArgumentException.class, "Substring parameter cannot be empty", () ->
+                StringUtil.wordsContainSubstringIgnoreCase("typical sentence", "  "));
     }
 
     @Test
     public void wordsContainSubstringIgnoreCase_nullSentence_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> StringUtil.wordsContainSubstringIgnoreCase(null, "abc"));
+        assertThrows(NullPointerException.class, () ->
+                StringUtil.wordsContainSubstringIgnoreCase(null, "abc"));
     }
 
     /*
@@ -180,14 +183,18 @@ public class StringUtilTest {
         assertFalse(StringUtil.wordsContainSubstringIgnoreCase("    ", "123"));
 
         // Matches a partial word in the sentence
-        assertTrue(StringUtil.wordsContainSubstringIgnoreCase("aaa bbb ccc", "bb")); // Sentence word bigger than query word
-        assertFalse(StringUtil.wordsContainSubstringIgnoreCase("aaa bbb ccc", "bbbb")); // Query word bigger than sentence word
+        // Sentence word bigger than query word
+        assertTrue(StringUtil.wordsContainSubstringIgnoreCase("aaa bbb ccc", "bb"));
+        // Query word bigger than sentence word
+        assertFalse(StringUtil.wordsContainSubstringIgnoreCase("aaa bbb ccc", "bbbb"));
 
         // Matches partial word in the sentence, different upper/lower case letters
         assertTrue(StringUtil.wordsContainSubstringIgnoreCase("aaa bBb ccc", "Bb")); // First word (boundary case)
         assertTrue(StringUtil.wordsContainSubstringIgnoreCase("aaa bBb ccc@1", "C@1")); // Last word (boundary case)
-        assertTrue(StringUtil.wordsContainSubstringIgnoreCase("  AAA   bBb   ccc  ", "aa")); // Sentence has extra spaces
-        assertTrue(StringUtil.wordsContainSubstringIgnoreCase("Aaa", "aa")); // Only one word in sentence (boundary case)
+        // Sentence has extra spaces
+        assertTrue(StringUtil.wordsContainSubstringIgnoreCase("  AAA   bBb   ccc  ", "aa"));
+        // Only one word in sentence (boundary case)
+        assertTrue(StringUtil.wordsContainSubstringIgnoreCase("Aaa", "aa"));
         assertTrue(StringUtil.wordsContainSubstringIgnoreCase("aaa bbb ccc", "  cc  ")); // Leading/trailing spaces
 
         // Matches multiple words in sentence


### PR DESCRIPTION
Change find command so that it does a substring search for certain parameters that are inconvenient to query by whole words.

Specifically:
- Name (Searching by short forms of long names)
- Email (Searching for emails without having to type out domain names)
- Location (Searching for long addresses made easier)
- Phone (Searching for people by phone possible even if the whole phone number is not memorised)
Resolves #80 , resolves #87 