### PR TITLE
Delete Command Mass Operation

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -137,7 +137,7 @@ Format: `delete INDEX…​`
 
 Examples:
 * `list -pa` followed by `delete 2` deletes the 2nd patient in the listed patients.
-* `find -sp s/s/Orthopaedic` followed by `delete 2 3 4` deletes the 2nd, 3rd and 4th specialist listed in the `find` command.
+* `find -sp s/Orthopaedic` followed by `delete 2 3 4` deletes the 2nd, 3rd and 4th specialist listed in the `find` command.
 
 ### Clearing all entries : `clear`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -53,7 +53,10 @@ would like the command to operate on.
 * Items in square brackets are optional.<br>
   e.g `n/NAME [m/MEDICAL_HISTORY]` can be used as `n/John Doe m/Osteoporosis` or as `n/John Doe`.
 
-* Items with `…`​ after them can be used multiple times including zero times.<br>
+* Items with `…`​ after them can be used multiple times but must include at least one entry.<br>
+  e.g. `INDEX…​` can be used as `1` , `1 2 3`, `4 5 6 7 8`, but _**not**_ ` ` (i.e. 0 times).
+
+* Items with both square brackets and `…`​ can be used multiple times, including zero times as they are optional. <br>
   e.g. `[m/MEDICAL_HISTORY]…​` can be used as ` ` (i.e. 0 times), `m/Osteoporosis`, `m/Osteoporosis m/Asthma` etc.
 
 * Parameters can be in any order.<br>
@@ -123,17 +126,18 @@ Examples:
 
 ### Deleting a patient or specialist : `delete`
 
-Deletes the specified patient or specialist from the stored records.
+Deletes the specified patients or specialists from the stored records.
 
-Format: `delete INDEX`
+Format: `delete INDEX…​`
 
-* Deletes the person at the specified `INDEX`.
+* Deletes all persons at the specified `INDEX…​`.
 * The index refers to the index number shown in the displayed person list.
 * The index **must be a positive integer** 1, 2, 3, …​ with a maximum value of the list size.
+* The indexes must **not** contain any duplicate integers.
 
 Examples:
-* `list -pa` followed by `delete 2` deletes the 2nd patient in the listed patients. 
-* `find -sp n/Betsy` followed by `delete 1` deletes the 1st specialist from the specialists listed in the `find` command.
+* `list -pa` followed by `delete 2` deletes the 2nd patient in the listed patients.
+* `find -sp s/s/Orthopaedic` followed by `delete 2 3 4` deletes the 2nd, 3rd and 4th specialist listed in the `find` command.
 
 ### Clearing all entries : `clear`
 

--- a/src/main/java/seedu/address/commons/core/index/Index.java
+++ b/src/main/java/seedu/address/commons/core/index/Index.java
@@ -10,7 +10,7 @@ import seedu.address.commons.util.ToStringBuilder;
  * base the other component is using for its index. However, after receiving the {@code Index}, that component can
  * convert it back to an int if the index will not be passed to a different component again.
  */
-public class Index {
+public class Index implements Comparable<Index> {
     private int zeroBasedIndex;
 
     /**
@@ -65,5 +65,10 @@ public class Index {
     @Override
     public String toString() {
         return new ToStringBuilder(this).add("zeroBasedIndex", zeroBasedIndex).toString();
+    }
+
+    @Override
+    public int compareTo(Index o) {
+        return this.zeroBasedIndex - o.zeroBasedIndex;
     }
 }

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -25,6 +25,9 @@ public class Messages {
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
 
+    public static final String MESSAGE_DUPLICATE_INDEXES =
+            "The following index(es) has been duplicated: ";
+
     /**
      * Returns an error message indicating the duplicate prefixes.
      */
@@ -35,6 +38,14 @@ public class Messages {
                 Stream.of(duplicatePrefixes).map(Prefix::toString).collect(Collectors.toSet());
 
         return MESSAGE_DUPLICATE_FIELDS + String.join(" ", duplicateFields);
+    }
+
+    /**
+     * Returns an error message indicating the duplicate indexes.
+     */
+    public static String getErrorMessageForDuplicateIndexes(String[] duplicatedIndexes) {
+        assert duplicatedIndexes.length > 0;
+        return MESSAGE_DUPLICATE_INDEXES + String.join(", ", duplicatedIndexes);
     }
 
     /**
@@ -52,7 +63,7 @@ public class Messages {
 
         if (person instanceof Patient) {
             Patient patient = (Patient) person;
-            builder.insert(0, "Patient ")
+            builder.insert(0, "Patient: ")
                     .append("; Age: ")
                     .append(patient.getAge())
                     .append("; Medical History: ")
@@ -61,7 +72,7 @@ public class Messages {
 
         if (person instanceof Specialist) {
             Specialist specialist = (Specialist) person;
-            builder.insert(0, "Specialist ")
+            builder.insert(0, "Specialist: ")
                     .append("; Specialty: ")
                     .append(specialist.getSpecialty());
         }
@@ -74,12 +85,12 @@ public class Messages {
      */
     public static String formatShortForm(Person person) {
         final StringBuilder result = new StringBuilder();
-        result.append(person.getName()).append("; Email: ").append(person.getEmail());
+        result.append(person.getName()).append("; Phone: ").append(person.getPhone());
         if (person instanceof Patient) {
-            result.insert(0, "Patient ");
+            result.insert(0, "Patient: ");
         }
         if (person instanceof Specialist) {
-            result.insert(0, "Specialist ");
+            result.insert(0, "Specialist: ");
         }
         return result.toString();
     }

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -68,4 +68,19 @@ public class Messages {
         return builder.toString();
     }
 
+    /**
+     * Formats a shorten form of {@code person} for display to the user.
+     * Displays the {@code Name}, {@code Email} and {@code PersonType} of the person.
+     */
+    public static String formatShortForm(Person person) {
+        final StringBuilder result = new StringBuilder();
+        result.append(person.getName()).append("; Email: ").append(person.getEmail());
+        if (person instanceof Patient) {
+            result.insert(0, "Patient ");
+        }
+        if (person instanceof Specialist) {
+            result.insert(0, "Specialist ");
+        }
+        return result.toString();
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -21,7 +21,7 @@ public class DeleteCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the person identified by the index number(s) used in the displayed person list.\n"
             + "Parameters: INDEX... (must be a positive integer and within range of displayed person list)\n"
-            + "INDEX... must be white space separated and must not contain duplicates\n"
+            + "INDEX... must be whitespace separated and must not contain duplicates\n"
             + "Example: " + COMMAND_WORD + " "
             + "1 3 4";
     public static final String MESSAGE_DELETE_PERSON_SUCCESS_HEADER = "Deleted %d Person(s):";

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -19,10 +19,11 @@ public class DeleteCommand extends Command {
     public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the person identified by the index number used in the displayed person list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
+            + ": Deletes the person identified by the index number(s) used in the displayed person list.\n"
+            + "Parameters: INDEX... (must be a positive integer and within range of displayed person list)\n"
+            + "INDEX... must be white space separated and must not contain duplicates\n"
             + "Example: " + COMMAND_WORD + " "
-            + "1";
+            + "1 3 4";
     public static final String MESSAGE_DELETE_PERSON_SUCCESS_HEADER = "Deleted %d Person(s):";
     private final List<Index> targetIndexes;
 
@@ -44,9 +45,10 @@ public class DeleteCommand extends Command {
         }
         StringBuilder resultMessage =
                 new StringBuilder(String.format(MESSAGE_DELETE_PERSON_SUCCESS_HEADER, targetIndexes.size()));
-        for (Index targetIndex: targetIndexes) {
+        for (int i = 0; i < targetIndexes.size(); i++) {
+            Index targetIndex = targetIndexes.get(i);
             Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
-            resultMessage.append(String.format("\n%1$d: %2$s", targetIndex.getOneBased(),
+            resultMessage.append(String.format("\n%1$d. %2$s", i + 1,
                             Messages.formatShortForm(personToDelete)));
         }
         for (int i = targetIndexes.size() - 1; i >= 0; i--) {

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -2,9 +2,13 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.util.List;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+
+
 
 /**
  * Parses input arguments and creates a new DeleteCommand object
@@ -18,8 +22,8 @@ public class DeleteCommandParser implements ParserBasic<DeleteCommand> {
      */
     public DeleteCommand parse(String args) throws ParseException {
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeleteCommand(index);
+            List<Index> indexList = ParserUtil.parseIndexes(args);
+            return new DeleteCommand(indexList);
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -26,7 +26,8 @@ public class DeleteCommandParser implements ParserBasic<DeleteCommand> {
             return new DeleteCommand(indexList);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                            pe.getMessage() + "\n" + DeleteCommand.MESSAGE_USAGE), pe);
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -28,7 +28,8 @@ import seedu.address.model.tag.Tag;
  */
 public class ParserUtil {
 
-    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_INVALID_INDEX =
+            "The provided indexes must be positive whole numbers (integers greater than zero).";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -53,10 +54,10 @@ public class ParserUtil {
         String trimmedIndexes = oneBasedIndexes.trim();
         List<Index> indexList = new ArrayList<>();
         String[] args = trimmedIndexes.split("\\s+");
-        verifyNoDuplicateIndexes(args);
         for (String arg : args) {
             indexList.add(parseIndex(arg));
         }
+        verifyNoDuplicateIndexes(args);
         Collections.sort(indexList);
         return indexList;
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,8 +2,12 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
@@ -36,6 +40,23 @@ public class ParserUtil {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
+    }
+
+    /**
+     * Parses {@code oneBasedIndexes} into a list of sorted {@code Index} in ascending order and returns it.
+     * Leading and trailing whitespaces will be trimmed.
+     * @throws ParseException if any of the specified index is invalid (not non-zero unsigned integer)
+     */
+    public static List<Index> parseIndexes(String oneBasedIndexes) throws ParseException {
+        requireNonNull(oneBasedIndexes);
+        String trimmedIndexes = oneBasedIndexes.trim();
+        List<Index> indexList = new ArrayList<>();
+        String[] args = trimmedIndexes.split("\\s+");
+        for (String arg : args) {
+            indexList.add(parseIndex(arg));
+        }
+        Collections.sort(indexList);
+        return indexList;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -11,6 +12,7 @@ import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
+import seedu.address.logic.Messages;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Age;
 import seedu.address.model.person.Email;
@@ -51,11 +53,25 @@ public class ParserUtil {
         String trimmedIndexes = oneBasedIndexes.trim();
         List<Index> indexList = new ArrayList<>();
         String[] args = trimmedIndexes.split("\\s+");
+        verifyNoDuplicateIndexes(args);
         for (String arg : args) {
             indexList.add(parseIndex(arg));
         }
         Collections.sort(indexList);
         return indexList;
+    }
+
+    /**
+     * Verifies that no duplicated indexes are present in user input argument.
+     */
+    private static void verifyNoDuplicateIndexes(String[] args) throws ParseException {
+        String[] duplicatedIndexes = Arrays.stream(args)
+                .filter(i -> Collections.frequency(Arrays.asList(args), i) > 1)
+                .distinct()
+                .toArray(String[]::new);
+        if (duplicatedIndexes.length > 0) {
+            throw new ParseException(Messages.getErrorMessageForDuplicateIndexes(duplicatedIndexes));
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -37,7 +37,7 @@ public class DeleteCommandTest {
         DeleteCommand deleteCommand = new DeleteCommand(List.of(INDEX_FIRST_PERSON));
         StringBuilder expectedMessageBuilder =
                 new StringBuilder(String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS_HEADER, 1));
-        expectedMessageBuilder.append(String.format("\n%1$d: %2$s", 1,
+        expectedMessageBuilder.append(String.format("\n%1$d. %2$s", 1,
                 Messages.formatShortForm(personToDelete)));
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
@@ -54,10 +54,11 @@ public class DeleteCommandTest {
         StringBuilder expectedMessageBuilder =
                 new StringBuilder(String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS_HEADER, indexList.size()));
         List<Person> personsToDelete = new ArrayList<>();
-        for (Index index: indexList) {
+        for (int i = 0; i < indexList.size(); i++) {
+            Index index = indexList.get(i);
             Person currPerson = model.getFilteredPersonList().get(index.getZeroBased());
             personsToDelete.add(currPerson);
-            expectedMessageBuilder.append(String.format("\n%1$d: %2$s", index.getOneBased(),
+            expectedMessageBuilder.append(String.format("\n%1$d. %2$s", i + 1,
                             Messages.formatShortForm(currPerson)));
         }
         DeleteCommand deleteCommand = new DeleteCommand(indexList);
@@ -86,7 +87,7 @@ public class DeleteCommandTest {
 
         StringBuilder expectedMessageBuilder =
                 new StringBuilder(String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS_HEADER, 1));
-        expectedMessageBuilder.append(String.format("\n%1$d: %2$s", 1,
+        expectedMessageBuilder.append(String.format("\n%1$d. %2$s", 1,
                 Messages.formatShortForm(personToDelete)));
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
@@ -63,16 +64,12 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommand_delete_patient() throws Exception {
+    public void parseCommand_delete() throws Exception {
+        List<Index> indexList =
+                Arrays.asList(Index.fromOneBased(1), Index.fromOneBased(2), Index.fromOneBased(4));
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
-    }
-    @Test
-    public void parseCommand_delete_specialist() throws Exception {
-        DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+                DeleteCommand.COMMAND_WORD + " " + "1 2 4");
+        assertEquals(new DeleteCommand(indexList), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -5,10 +5,12 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseBasicF
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseBasicSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 
 
@@ -25,13 +27,26 @@ public class DeleteCommandParserTest {
     private DeleteCommandParser parser = new DeleteCommandParser();
 
     @Test
-    public void parse_validArgs_returnsDeleteCommand() {
+    public void parse_validSingleIndexArg_returnsDeleteCommand() {
         assertParseBasicSuccess(parser, "1", new DeleteCommand(List.of(INDEX_FIRST_PERSON)));
+    }
+
+    @Test
+    public void parse_validMultiIndexArg_returnsDeleteCommand() {
+        List<Index> indexList = Arrays.asList(Index.fromOneBased(1),
+                Index.fromOneBased(2), Index.fromOneBased(3));
+        assertParseBasicSuccess(parser, "1 2 3", new DeleteCommand(indexList));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseBasicFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_multiArgSingleInvalid_throwsParseException() {
+        assertParseBasicFailure(parser, "1 2 a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 DeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.DeleteCommand;
 
 
@@ -41,12 +42,25 @@ public class DeleteCommandParserTest {
     @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseBasicFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                DeleteCommand.MESSAGE_USAGE));
+                ParserUtil.MESSAGE_INVALID_INDEX
+                + "\n"
+                + DeleteCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_multiArgSingleInvalid_throwsParseException() {
         assertParseBasicFailure(parser, "1 2 a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                DeleteCommand.MESSAGE_USAGE));
+                ParserUtil.MESSAGE_INVALID_INDEX
+                + "\n"
+                + DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_duplicatedIndexes_throwsParseException() {
+        String[] duplicatedIndexes = {"1", "3"};
+        assertParseBasicFailure(parser, "1 1 2 3 3 4 5",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        Messages.getErrorMessageForDuplicateIndexes(duplicatedIndexes)
+                                + "\n" + DeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -5,13 +5,17 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseBasicF
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseBasicSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.DeleteCommand;
 
+
+
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
- * outside of the DeleteCommand code. For example, inputs "1" and "1 abc" take the
+ * outside the DeleteCommand code. For example, inputs "1" and "1 abc" take the
  * same path through the DeleteCommand, and therefore we test only one of them.
  * The path variation for those two cases occur inside the ParserUtil, and
  * therefore should be covered by the ParserUtilTest.
@@ -22,7 +26,7 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseBasicSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
+        assertParseBasicSuccess(parser, "1", new DeleteCommand(List.of(INDEX_FIRST_PERSON)));
     }
 
     @Test


### PR DESCRIPTION
# Notes:
Resolves #31 

## Expected Behaviour
- `delete` command can now accept multiple indexes instead of only one, to support multiple deletions with a single command.
- As of now, the indexes of the delete command cannot have any duplicate integers. i.e. `delete 1 2 3 4 5 1` should return a useful error message indicating to the user which indexes have been duplicated.
- In the event that both non-positive whole number and duplicated indexes exist in the user input arguments. <br> e.g. `delete 1 1 2 3 a b c`, the parser will prioritise showing an error message for non-positive whole number first.


## Note to other developers
- The "Notes about the command format" section in the User Guide has been updated to include different annotations for `1...n` arguments and `0...n` arguments. 