### PR TITLE
Recall Recent Commands Feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,4 +69,8 @@ shadowJar {
     archiveFileName = 'addressbook.jar'
 }
 
+run {
+    enableAssertions = true
+}
+
 defaultTasks 'clean', 'test'

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -147,6 +147,18 @@ Exits the program.
 
 Format: `exit`
 
+### Recalling Recent Commands
+
+Similar to the [CLI of Unix](https://www.osc.edu/book/export/html/3022), the CLI of DoConnek Pro provides the functionality of
+recalling recent commands by pressing the 'up arrow' and the 'down arrow' on the keyboard.
+
+DoConnek Pro maintains a history of the 20 most recent commands the user has entered.
+
+The user can recall the 20 most recently entered commands by pressing the up arrow on the keyboard. Each press of the 
+up arrow cycles one command further back in the history.
+
+If the user goes too far back in history, they can 'undo' an 'up arrow' by pressing the down arrow.
+
 ### Save and Load Data
 
 The patient and specialist data will automatically be saved to the device’s harddrive every time the data is updated, and will automatically be loaded when the user starts the application. The user does not need to manually save any data.

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -47,4 +47,18 @@ public interface Logic {
      * Set the user prefs' GUI settings.
      */
     void setGuiSettings(GuiSettings guiSettings);
+
+    /**
+     * Returns the command string of the next most recent command executed.
+     */
+    String getNextCommandString(String currentCommandString);
+
+    /**
+     * Returns the command string of the previous most recent command executed.
+     */
+    String getPrevCommandString(String currentCommandString);
+    /**
+     * Adds the most recent command string input by the user to the CommandStringStash.
+     */
+    void addCommandString(String commandString);
 }

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -51,12 +51,12 @@ public interface Logic {
     /**
      * Returns the command string of the next most recent command executed.
      */
-    String getNextCommandString(String currentCommandString);
+    String getPrevCommandString(String currentCommandString);
 
     /**
      * Returns the command string of the previous most recent command executed.
      */
-    String getPrevCommandString(String currentCommandString);
+    String getPassedCommandString(String currentCommandString);
     /**
      * Adds the most recent command string input by the user to the CommandStringStash.
      */

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -85,4 +85,20 @@ public class LogicManager implements Logic {
     public void setGuiSettings(GuiSettings guiSettings) {
         model.setGuiSettings(guiSettings);
     }
+
+    @Override
+    public String getNextCommandString(String currentCommandString) {
+        return model.getNextCommandString(currentCommandString);
+    }
+
+    @Override
+    public String getPrevCommandString(String currentCommandString) {
+        return model.getPrevCommandString(currentCommandString);
+    }
+
+    @Override
+    public void addCommandString(String commandString) {
+        model.addCommandString(commandString);
+    }
+
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -87,13 +87,13 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public String getNextCommandString(String currentCommandString) {
-        return model.getNextCommandString(currentCommandString);
+    public String getPrevCommandString(String currentCommandString) {
+        return model.getPrevCommandString(currentCommandString);
     }
 
     @Override
-    public String getPrevCommandString(String currentCommandString) {
-        return model.getPrevCommandString(currentCommandString);
+    public String getPassedCommandString(String currentCommandString) {
+        return model.getPassedCommandString(currentCommandString);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/CommandStringStash.java
+++ b/src/main/java/seedu/address/model/CommandStringStash.java
@@ -2,6 +2,7 @@ package seedu.address.model;
 
 import java.util.Deque;
 import java.util.LinkedList;
+import java.util.Objects;
 
 /**
  * Represents a stash that contains the command String of the 20 most recent
@@ -77,4 +78,19 @@ public class CommandStringStash {
         this.prevCmdStringsStack.addFirst(commandInputString);
     }
 
+    @Override
+    public boolean equals(Object object) {
+        if (object == null || !(object instanceof CommandStringStash)) {
+            return false;
+        }
+        CommandStringStash commandStringStash = (CommandStringStash) object;
+        return isNext == commandStringStash.isNext
+                && Objects.equals(prevCmdStringsStack, commandStringStash.prevCmdStringsStack)
+                && Objects.equals(passedCmdStringsStack, commandStringStash.passedCmdStringsStack);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(prevCmdStringsStack, passedCmdStringsStack, isNext);
+    }
 }

--- a/src/main/java/seedu/address/model/CommandStringStash.java
+++ b/src/main/java/seedu/address/model/CommandStringStash.java
@@ -1,0 +1,80 @@
+package seedu.address.model;
+
+import java.util.Deque;
+import java.util.LinkedList;
+
+/**
+ * Represents a stash that contains the command String of the 20 most recent
+ * command executed.
+ */
+public class CommandStringStash {
+    private Deque<String> prevCmdStringsStack;
+    private Deque<String> passedCmdStringsStack;
+    private boolean isNext;
+
+    /**
+     * Basic empty constructor for the CommandStringStash.
+     */
+    public CommandStringStash() {
+        this.prevCmdStringsStack = new LinkedList<>();
+        this.passedCmdStringsStack = new LinkedList<>();
+        this.isNext = true;
+    }
+
+    public String getNextCommandString(String commandInputString) {
+        assert commandInputString != null;
+        if (prevCmdStringsStack.isEmpty()) {
+            return commandInputString;
+        }
+
+        String nextCommandString = prevCmdStringsStack.removeFirst();
+        this.passedCmdStringsStack.addFirst(nextCommandString);
+
+        if (!isNext) {
+            // skip over this string as it was just added to the stack
+            isNext = true;
+            return getNextCommandString(commandInputString);
+        }
+        return nextCommandString;
+    }
+
+    public String getPrevCommandString(String commandInputString) {
+        assert commandInputString != null;
+        if (passedCmdStringsStack.isEmpty()) {
+            return commandInputString;
+        }
+
+        String prevCommandString = passedCmdStringsStack.removeFirst();
+        this.prevCmdStringsStack.addFirst(prevCommandString);
+
+        if (isNext) {
+            // skip over this string as it was just added to the stack
+            isNext = false;
+            return getPrevCommandString(commandInputString);
+        }
+        return prevCommandString;
+    }
+
+    /**
+     * Adds the {@code commandString} to the stash of command Strings.
+     * If the stash has size > 20, the least recently added command string is evicted.
+     * @param commandInputString A non-null command input String.
+     */
+    public void addCommandString(String commandInputString) {
+        assert commandInputString != null;
+
+        // evict least recently added command string if necessary
+        while (this.passedCmdStringsStack.size() + prevCmdStringsStack.size() >= 20) {
+            this.prevCmdStringsStack.removeLast();
+        }
+
+        // reset the command string stacks
+        while (!this.passedCmdStringsStack.isEmpty()) {
+            this.prevCmdStringsStack.addFirst(passedCmdStringsStack.removeFirst());
+        }
+        this.isNext = true;
+
+        this.prevCmdStringsStack.addFirst(commandInputString);
+    }
+
+}

--- a/src/main/java/seedu/address/model/CommandStringStash.java
+++ b/src/main/java/seedu/address/model/CommandStringStash.java
@@ -4,6 +4,8 @@ import java.util.Deque;
 import java.util.LinkedList;
 import java.util.Objects;
 
+import seedu.address.commons.util.ToStringBuilder;
+
 /**
  * Represents a stash that contains the command String of the 20 most recent
  * command executed.
@@ -22,7 +24,21 @@ public class CommandStringStash {
         this.isNext = true;
     }
 
-    public String getNextCommandString(String commandInputString) {
+    /**
+     * Creates the CommandStringStash using the initial values provided.
+     */
+    public CommandStringStash(Deque<String> prevCmdStringsStack, Deque<String> passedCmdStringsStack, boolean isNext) {
+        this.prevCmdStringsStack = prevCmdStringsStack;
+        this.passedCmdStringsStack = passedCmdStringsStack;
+        this.isNext = isNext;
+    }
+
+    /**
+     * Returns the previous command string input entered by the user.
+     * Remembers the state, so it passes previous command string inputs already gotten.
+     * Returns {@code commandInputString} if already at the first command string input entered.
+     */
+    public String getPrevCommandString(String commandInputString) {
         assert commandInputString != null;
         if (prevCmdStringsStack.isEmpty()) {
             return commandInputString;
@@ -34,12 +50,17 @@ public class CommandStringStash {
         if (!isNext) {
             // skip over this string as it was just added to the stack
             isNext = true;
-            return getNextCommandString(commandInputString);
+            return getPrevCommandString(commandInputString);
         }
         return nextCommandString;
     }
 
-    public String getPrevCommandString(String commandInputString) {
+    /**
+     * Returns the command string input passed by the user acting as an "undo" of {@code getPrevCommandString}.
+     * Remember the state, so it passes command string inputs already "undone".
+     * Returns {@code commandInputString} if the user has not passed any commands yet.
+     */
+    public String getPassedCommandString(String commandInputString) {
         assert commandInputString != null;
         if (passedCmdStringsStack.isEmpty()) {
             return commandInputString;
@@ -51,7 +72,7 @@ public class CommandStringStash {
         if (isNext) {
             // skip over this string as it was just added to the stack
             isNext = false;
-            return getPrevCommandString(commandInputString);
+            return getPassedCommandString(commandInputString);
         }
         return prevCommandString;
     }
@@ -59,6 +80,7 @@ public class CommandStringStash {
     /**
      * Adds the {@code commandString} to the stash of command Strings.
      * If the stash has size > 20, the least recently added command string is evicted.
+     * Also resets the state of the stash.
      * @param commandInputString A non-null command input String.
      */
     public void addCommandString(String commandInputString) {
@@ -80,17 +102,24 @@ public class CommandStringStash {
 
     @Override
     public boolean equals(Object object) {
-        if (object == null || !(object instanceof CommandStringStash)) {
+        if (!(object instanceof CommandStringStash)) {
             return false;
         }
         CommandStringStash commandStringStash = (CommandStringStash) object;
-        return isNext == commandStringStash.isNext
-                && Objects.equals(prevCmdStringsStack, commandStringStash.prevCmdStringsStack)
+        return Objects.equals(prevCmdStringsStack, commandStringStash.prevCmdStringsStack)
                 && Objects.equals(passedCmdStringsStack, commandStringStash.passedCmdStringsStack);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(prevCmdStringsStack, passedCmdStringsStack, isNext);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("Previous Command Strings", prevCmdStringsStack)
+                .add("Passed Command Strings", passedCmdStringsStack)
+                .toString();
     }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -84,4 +84,20 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Returns the command string of the next most recent command executed.
+     */
+    String getNextCommandString(String currentCommandString);
+
+    /**
+     * Returns the command string of the previous most recent command executed.
+     */
+    String getPrevCommandString(String currentCommandString);
+
+    /**
+     * Adds the most recent command string input by the user to the CommandStringStash.
+     */
+    void addCommandString(String commandString);
+
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -88,12 +88,12 @@ public interface Model {
     /**
      * Returns the command string of the next most recent command executed.
      */
-    String getNextCommandString(String currentCommandString);
+    String getPrevCommandString(String currentCommandString);
 
     /**
      * Returns the command string of the previous most recent command executed.
      */
-    String getPrevCommandString(String currentCommandString);
+    String getPassedCommandString(String currentCommandString);
 
     /**
      * Adds the most recent command string input by the user to the CommandStringStash.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -23,6 +23,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
+    private final CommandStringStash commandStringStash;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -35,6 +36,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        this.commandStringStash = new CommandStringStash();
 
         // DoConnek Pro shows all patients on startup by default.
         updateFilteredPersonList(PersonType.PATIENT.getSearchPredicate());
@@ -130,6 +132,23 @@ public class ModelManager implements Model {
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+    }
+
+    //=========== Command String Stash =============================================================
+
+    @Override
+    public String getNextCommandString(String currentCommandString) {
+        return commandStringStash.getNextCommandString(currentCommandString);
+    }
+
+    @Override
+    public String getPrevCommandString(String currentCommandString) {
+        return commandStringStash.getPrevCommandString(currentCommandString);
+    }
+
+    @Override
+    public void addCommandString(String commandString) {
+        commandStringStash.addCommandString(commandString);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -137,13 +137,13 @@ public class ModelManager implements Model {
     //=========== Command String Stash =============================================================
 
     @Override
-    public String getNextCommandString(String currentCommandString) {
-        return commandStringStash.getNextCommandString(currentCommandString);
+    public String getPrevCommandString(String currentCommandString) {
+        return commandStringStash.getPrevCommandString(currentCommandString);
     }
 
     @Override
-    public String getPrevCommandString(String currentCommandString) {
-        return commandStringStash.getPrevCommandString(currentCommandString);
+    public String getPassedCommandString(String currentCommandString) {
+        return commandStringStash.getPassedCommandString(currentCommandString);
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -3,6 +3,8 @@ package seedu.address.ui;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -17,18 +19,22 @@ public class CommandBox extends UiPart<Region> {
     private static final String FXML = "CommandBox.fxml";
 
     private final CommandExecutor commandExecutor;
-
+    private final KeyPressExecutor keyUpExecutor;
+    private final KeyPressExecutor keyDownExecutor;
     @FXML
     private TextField commandTextField;
 
     /**
      * Creates a {@code CommandBox} with the given {@code CommandExecutor}.
      */
-    public CommandBox(CommandExecutor commandExecutor) {
+    public CommandBox(CommandExecutor commandExecutor, KeyPressExecutor keyUpExecutor, KeyPressExecutor keyDownExecutor) {
         super(FXML);
         this.commandExecutor = commandExecutor;
+        this.keyUpExecutor = keyUpExecutor;
+        this.keyDownExecutor = keyDownExecutor;
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
+        commandTextField.setOnKeyPressed(this::handleOnKeyPressed);
     }
 
     /**
@@ -70,6 +76,18 @@ public class CommandBox extends UiPart<Region> {
     }
 
     /**
+     * Handles the key pressed event.
+     */
+    private void handleOnKeyPressed(KeyEvent event) {
+        if (event.getCode() == KeyCode.UP) {
+            commandTextField.setText(keyUpExecutor.executeKey(commandTextField.getText()));
+            commandTextField.positionCaret(commandTextField.getText().length());
+        } else if (event.getCode() == KeyCode.DOWN) {
+            commandTextField.setText(keyDownExecutor.executeKey(commandTextField.getText()));
+            commandTextField.positionCaret(commandTextField.getText().length());
+        }
+    }
+    /**
      * Represents a function that can execute commands.
      */
     @FunctionalInterface
@@ -82,4 +100,14 @@ public class CommandBox extends UiPart<Region> {
         CommandResult execute(String commandText) throws CommandException, ParseException;
     }
 
+    /**
+     * Represents a function that executes a key press.
+     */
+    @FunctionalInterface
+    public interface KeyPressExecutor {
+        /**
+         * Executes the key press and returns the result String.
+         */
+        String executeKey(String commandText);
+    }
 }

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -27,7 +27,8 @@ public class CommandBox extends UiPart<Region> {
     /**
      * Creates a {@code CommandBox} with the given {@code CommandExecutor}.
      */
-    public CommandBox(CommandExecutor commandExecutor, KeyPressExecutor keyUpExecutor, KeyPressExecutor keyDownExecutor) {
+    public CommandBox(CommandExecutor commandExecutor, KeyPressExecutor keyUpExecutor, KeyPressExecutor
+            keyDownExecutor) {
         super(FXML);
         this.commandExecutor = commandExecutor;
         this.keyUpExecutor = keyUpExecutor;

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -119,7 +119,8 @@ public class MainWindow extends UiPart<Stage> {
         StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
-        CommandBox commandBox = new CommandBox(this::executeCommand);
+        CommandBox commandBox = new CommandBox(this::executeCommand,
+                logic::getNextCommandString, logic::getPrevCommandString);
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
     }
 
@@ -175,6 +176,7 @@ public class MainWindow extends UiPart<Stage> {
     private CommandResult executeCommand(String commandText) throws CommandException, ParseException {
         try {
             CommandResult commandResult = logic.execute(commandText);
+            logic.addCommandString(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -120,7 +120,7 @@ public class MainWindow extends UiPart<Stage> {
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
         CommandBox commandBox = new CommandBox(this::executeCommand,
-                logic::getNextCommandString, logic::getPrevCommandString);
+                logic::getPrevCommandString, logic::getPassedCommandString);
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -158,6 +158,21 @@ public class AddCommandTest {
             throw new AssertionError("This method should not be called.");
 
         }
+
+        @Override
+        public String getNextCommandString(String currentCommandString) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public String getPrevCommandString(String currentCommandString) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addCommandString(String commandString) {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -160,12 +160,12 @@ public class AddCommandTest {
         }
 
         @Override
-        public String getNextCommandString(String currentCommandString) {
+        public String getPrevCommandString(String currentCommandString) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public String getPrevCommandString(String currentCommandString) {
+        public String getPassedCommandString(String currentCommandString) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/model/CommandStringStashTest.java
+++ b/src/test/java/seedu/address/model/CommandStringStashTest.java
@@ -1,0 +1,27 @@
+package seedu.address.model;
+
+public class CommandStringStashTest {
+
+    private final CommandStringStash commandStringStash = new CommandStringStash();
+
+    public void addCommandString_withValidCommandString_evictsCorrectly() {
+
+    }
+
+    public void addCommandString_withValidCommandString_resetsStashes() {
+
+    }
+
+    public void addCommandString_withValidCommandString_resetsStacks() {
+
+    }
+
+    public void addCommandString_withValidCommandString_addsCorrectly() {
+
+    }
+
+    public void addCommandString_withNull_throwsException() {
+
+    }
+
+}

--- a/src/test/java/seedu/address/model/CommandStringStashTest.java
+++ b/src/test/java/seedu/address/model/CommandStringStashTest.java
@@ -1,27 +1,173 @@
 package seedu.address.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
 public class CommandStringStashTest {
 
-    private final CommandStringStash commandStringStash = new CommandStringStash();
-
-    public void addCommandString_withValidCommandString_evictsCorrectly() {
-
-    }
-
-    public void addCommandString_withValidCommandString_resetsStashes() {
-
-    }
-
-    public void addCommandString_withValidCommandString_resetsStacks() {
-
-    }
-
+    @Test
     public void addCommandString_withValidCommandString_addsCorrectly() {
+        CommandStringStash commandStringStash = new CommandStringStash();
+        CommandStringStash expectedCommandStringStash = new CommandStringStash(
+                new LinkedList<>(Arrays.asList("0")),
+                new LinkedList<>(),
+                true
+        );
 
+        commandStringStash.addCommandString("0");
+
+        assertEquals(expectedCommandStringStash, commandStringStash);
     }
 
-    public void addCommandString_withNull_throwsException() {
+    @Test
+    public void addCommandString_withValidCommandString_evictsCorrectly() {
+        String[] prevCmdStringsStack = createCmdStringStackIntegers(0, 19, false);
+        CommandStringStash commandStringStash = new CommandStringStash(
+                new LinkedList<>(Arrays.asList(prevCmdStringsStack)),
+                new LinkedList<>(),
+                true);
 
+        String[] expectedCmdStringsStack = createCmdStringStackIntegers(1, 20, false);
+        CommandStringStash expectedCommandStringStash = new CommandStringStash(
+                new LinkedList<>(Arrays.asList(expectedCmdStringsStack)),
+                new LinkedList<>(),
+                true);
+
+        commandStringStash.addCommandString("20");
+
+        assertEquals(expectedCommandStringStash, commandStringStash);
+    }
+
+    @Test
+    public void addCommandString_withValidCommandString_resetsStash() {
+        String[] prevCmdStringsStack = createCmdStringStackIntegers(1, 10, false);
+        String[] expectedCmdStringsStack = createCmdStringStackIntegers(0, 10, true);
+        CommandStringStash commandStringStash = new CommandStringStash(
+                new LinkedList<>(),
+                new LinkedList<>(Arrays.asList(prevCmdStringsStack)),
+                false);
+        CommandStringStash expectedCommandStringStash = new CommandStringStash(
+                new LinkedList<>(Arrays.asList(expectedCmdStringsStack)),
+                new LinkedList<>(),
+                true);
+
+        commandStringStash.addCommandString("0");
+
+        assertEquals(expectedCommandStringStash, commandStringStash);
+    }
+
+    @Test
+    public void getPrevCommandString_afterAdd_getsCorrectly() {
+        String[] prevCmdStringsStack = createCmdStringStackIntegers(1, 9, false);
+        String[] passedCmdStringsStack = createCmdStringStackIntegers(10, 15, true);
+        CommandStringStash commandStringStash = new CommandStringStash(
+                new LinkedList<>(Arrays.asList(prevCmdStringsStack)),
+                new LinkedList<>(Arrays.asList(passedCmdStringsStack)),
+                true
+        );
+
+        commandStringStash.addCommandString("16");
+
+        assertEquals("16", commandStringStash.getPrevCommandString("0"));
+    }
+
+    @Test
+    public void getPrevCommandString_afterGetPassed_getsCorrectly() {
+        String[] prevCmdStringsStack = createCmdStringStackIntegers(1, 9, false);
+        String[] passedCmdStringsStack = createCmdStringStackIntegers(10, 15, true);
+        CommandStringStash commandStringStash = new CommandStringStash(
+                new LinkedList<>(Arrays.asList(prevCmdStringsStack)),
+                new LinkedList<>(Arrays.asList(passedCmdStringsStack)),
+                false
+        );
+
+        commandStringStash.getPassedCommandString("0");
+
+        assertEquals("9", commandStringStash.getPrevCommandString("0"));
+    }
+
+    @Test
+    public void getPrevCommandString_afterGetPrev_getsCorrectly() {
+        String[] prevCmdStringsStack = createCmdStringStackIntegers(1, 9, false);
+        String[] passedCmdStringsStack = createCmdStringStackIntegers(10, 15, true);
+        CommandStringStash commandStringStash = new CommandStringStash(
+                new LinkedList<>(Arrays.asList(prevCmdStringsStack)),
+                new LinkedList<>(Arrays.asList(passedCmdStringsStack)),
+                true
+        );
+
+        commandStringStash.getPrevCommandString("0");
+
+        assertEquals("8", commandStringStash.getPrevCommandString("0"));
+    }
+
+    @Test
+    public void getPassedCommandString_afterAdd_getsCorrectly() {
+        String[] prevCmdStringsStack = createCmdStringStackIntegers(1, 9, false);
+        String[] passedCmdStringsStack = createCmdStringStackIntegers(10, 15, true);
+        CommandStringStash commandStringStash = new CommandStringStash(
+                new LinkedList<>(Arrays.asList(prevCmdStringsStack)),
+                new LinkedList<>(Arrays.asList(passedCmdStringsStack)),
+                true
+        );
+
+        commandStringStash.addCommandString("16");
+
+        assertEquals("0", commandStringStash.getPassedCommandString("0"));
+    }
+
+    @Test
+    public void getPassedCommandString_afterGetPassed_getsCorrectly() {
+        String[] prevCmdStringsStack = createCmdStringStackIntegers(1, 9, false);
+        String[] passedCmdStringsStack = createCmdStringStackIntegers(10, 15, true);
+        CommandStringStash commandStringStash = new CommandStringStash(
+                new LinkedList<>(Arrays.asList(prevCmdStringsStack)),
+                new LinkedList<>(Arrays.asList(passedCmdStringsStack)),
+                false
+        );
+
+        commandStringStash.getPassedCommandString("0");
+
+        assertEquals("11", commandStringStash.getPassedCommandString("0"));
+    }
+
+    @Test
+    public void getPassedCommandString_afterGetPrev_getsCorrectly() {
+        String[] prevCmdStringsStack = createCmdStringStackIntegers(1, 9, false);
+        String[] passedCmdStringsStack = createCmdStringStackIntegers(10, 15, true);
+        CommandStringStash commandStringStash = new CommandStringStash(
+                new LinkedList<>(Arrays.asList(prevCmdStringsStack)),
+                new LinkedList<>(Arrays.asList(passedCmdStringsStack)),
+                true
+        );
+
+        commandStringStash.getPrevCommandString("0");
+
+        assertEquals("10", commandStringStash.getPassedCommandString("0"));
+    }
+
+    /**
+     * Helper function to create an array of integers in increasing or decreasing order
+     * from {@code start} to {@code end}
+     */
+    public String[] createCmdStringStackIntegers(int start, int end, boolean increasing) {
+        int length = end - start + 1;
+        String[] cmdStringStack = new String[length];
+        for (int i = 0; i < length; i++) {
+            cmdStringStack[i] = String.valueOf(end - i);
+        }
+        if (increasing) {
+            List<String> list = Arrays.asList(cmdStringStack);
+            Collections.reverse(list);
+            cmdStringStack = list.toArray(cmdStringStack);
+        }
+        return cmdStringStack;
     }
 
 }


### PR DESCRIPTION
Resolves #85.
Functionality:
- User can press the 'up arrow' to repeat the most recent command entered. 
- Continuing to press the 'up arrow' allows the user to continue to cycle through the recent commands entered in reverse chronological order.
- Presssing the 'down arrow' allows the user to 'go back' a command.
- Update user guide, and add testing.
The failing code cov seems to be either changes in the UI or some trivial methods such as `toString` for the `CommandStringStash` class which I don't think necessitate automated tests so we should be safe to ignore them.