### PR TITLE
Modify Edit Command to align with View Command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -88,7 +88,6 @@ A patient can have any number of medical histories (including 0)
 
 Format (for specialists): `add -sp n/NAME e/EMAIL p/PHONE_NUMBER s/SPECIALISATION l/LOCATION`
 
-
 Examples:
 * `add -pa n/John p/12345678 a/21 m/Osteoporosis m/Rheumatoid arthritis`
 * `add -sp n/Jane p/73331515 s/Dermatologist l/Ang Mo Kio`
@@ -103,15 +102,15 @@ Examples:
 * `list -pa` Lists all patients in records.
 * `list -sp` Lists all specialists in records.
 
-### Locating persons by their attributes: `find`
+### Locating patients or specialists by their attributes: `find`
 
-Finds persons whose attributes contain any of the given keywords. 
+Finds patients or specialists whose attributes contain any of the given keywords. 
 Multiple attributes can be searched at once, the result will display any person
 with all attributes containing any of the corresponding keywords in the command.
 
 Format: `find -PERSON_TYPE [PREFIX/KEYWORDS]`
 
-* All prefixes are optional. Hence, calling `find -PERSON_TYPE` (without any prefixes) will result in all person of the specified type being listed.
+* All prefixes are optional. Hence, entering `find -PERSON_TYPE` (without any prefixes) will result in all person of the specified type being listed.
 * The search is case-insensitive.
   * e.g `hans` will match `Hans`
 * The order of the keywords does not matter. 
@@ -129,6 +128,33 @@ Examples:
 * `find -pa n/John` returns the patient `Johnny Depp` and the patient `John Doe`
 * `find -sp n/alex david` returns the specialists `Alex Yeoh` and `David Li` 
 * `find -sp n/Alex s/Orthopaedic` returns any specialists names including the string `Alex` who has the `Orthopaedic` specialty
+<br>
+
+### Editing a pre-existing patient or specialist record: `edit`
+
+Changes the content of a pre-existing patient or specialist record in the view panel.
+Multiple attributes of a person can be changed at once. The view panel will be updated with the
+modified results immediately after each successful command execution.
+
+Format: `edit PREFIX/KEYWORD…​`
+
+* When entering an `edit` command, at least one valid prefix must be present. 
+I.e. entering `edit` (without any prefixes) will result in an error message being displayed.
+* Only the patient or specialist in the view panel will be edited. Hence, when editing a specialist specific attribute
+while viewing a patient (or vice versa), an error message be displayed.
+  * e.g. when a patient is present in the view panel, `edit s/Dentistry` will result in an error message being displayed as
+  patients do not have the specialty attribute.
+* The new values of compulsory attributes for a patient or specialist cannot be empty.
+  * e.g. `edit s/` (empty Specialty attribute) will result in an error when trying to edit a specialist.
+  * e.g. `edit n/` (empty Name attribute) will result in an error when trying to edit a patient or specialist
+* The new values of temporary attributes can be empty. This is useful when you want to clear the content of optional attributes 
+in a patient or specialist.
+  * e.g. `edit t/` (empty Tag attribute) will remove the tags of the patient or specialist being displayed in the view panel
+
+Examples:
+* `list -pa` > `view 1` > `edit n/John Wick` modifies the name of the first patient in the list to `John Wick`.
+*  `find -sp t/friend` > `view 3` > `edit s/Surgery` modifies the specialty of the third specialist in the list with
+the `friend` tag.
 <br>
 
 ### Deleting a patient or specialist : `delete`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -146,10 +146,10 @@ while viewing a patient (or vice versa), an error message be displayed.
   patients do not have the specialty attribute.
 * The new values of compulsory attributes for a patient or specialist cannot be empty.
   * e.g. `edit s/` (empty Specialty attribute) will result in an error when trying to edit a specialist.
-  * e.g. `edit n/` (empty Name attribute) will result in an error when trying to edit a patient or specialist
-* The new values of temporary attributes can be empty. This is useful when you want to clear the content of optional attributes 
+  * e.g. `edit n/` (empty Name attribute) will result in an error when trying to edit a patient or specialist.
+* The new values of optional attributes can be empty. This is useful when you want to clear the content of optional attributes 
 in a patient or specialist.
-  * e.g. `edit t/` (empty Tag attribute) will remove the tags of the patient or specialist being displayed in the view panel
+  * e.g. `edit t/` (empty Tag attribute) will remove the tags of the patient or specialist being displayed in the view panel.
 
 Examples:
 * `list -pa` > `view 1` > `edit n/John Wick` modifies the name of the first patient in the list to `John Wick`.
@@ -273,7 +273,8 @@ Action | Format, Examples
 **Add (specialist)** | `add -sp n/NAME e/EMAIL p/PHONE_NUMBER s/SPECIALISATION l/LOCATION` <br> e.g., `add -sp n/Jane e/janejane@example.com p/73331515 s/Dermatologist l/Ang Mo Kio`
 **Clear** | `clear`
 **Delete** | `delete INDEX`<br> e.g., `delete 3`
-**Find** | `find -PERSON_TYPE KEYWORD [MORE_KEYWORDS]`<br> e.g., `find -pa n/James Jake p/73281193`
+**Find** | `find -PERSON_TYPE PREFIX/KEYWORD [MORE_PREFIX/KEYWORDS]`<br> e.g., `find -pa n/James Jake p/73281193`
+**Edit** | `edit PREFIX/KEYWORD [MORE_PREFIX/KEYWORDS]` <br> e.g. `edit n/Jonathan Wick p/09883100`
 **List** | `list -pa`
 **Undo** | `undo`
 **Redo** | `redo`

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -20,6 +20,8 @@ public class Messages {
             "Invalid person type! Specify either \"-pa\" for patient or \"-sp\" for specialist";
     public static final String MESSAGE_PERSON_TYPE_MISMATCH_INDEX =
             "The person type tag does not match the person type at the specified index.";
+    public static final String MESSAGE_ERROR_STATE =
+            "Something went wrong :( \n Please contact the developers via email or website.";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PATIENT_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_AGE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
@@ -10,7 +9,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SPECIALTY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.logic.parser.CliSyntax.SPECIALIST_TAG;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -34,7 +32,6 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Specialist;
 import seedu.address.model.person.Specialty;
-import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.tag.Tag;
 
 /**

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -34,6 +34,7 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Specialist;
 import seedu.address.model.person.Specialty;
+import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -115,9 +116,11 @@ public class EditCommand extends Command {
         if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
+
         model.setPerson(personToEdit, editedPerson);
         model.commitAddressBook();
         model.updateSelectedPerson(editedPerson);
+
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -399,7 +399,7 @@ public class EditCommand extends Command {
          */
         @Override
         public boolean isAnyFieldEdited() {
-            return super.isAnyFieldEdited() || CollectionUtil.isAnyNonNull(specialty);
+            return super.isAnyFieldEdited() || CollectionUtil.isAnyNonNull(location, specialty);
         }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -59,25 +59,21 @@ public class EditCommand extends Command {
                     + PREFIX_TAG + "owesMoney ";
 
     public static final String MESSAGE_USAGE_PATIENT = COMMAND_WORD + " "
-            + PATIENT_TAG
             + ": Edit a patient in the address book. \n"
             + MESSAGE_USAGE_GENERAL
             + PREFIX_AGE + "AGE "
             + PREFIX_MEDICALHISTORY + "MEDICAL HISTORY \n"
             + "Example: " + COMMAND_WORD + " "
-            + PATIENT_TAG + " "
             + PERSON_EXAMPLE
             + PREFIX_AGE + "30 "
             + PREFIX_MEDICALHISTORY + "Osteoporosis";
 
     public static final String MESSAGE_USAGE_SPECIALIST = COMMAND_WORD + " "
-            + SPECIALIST_TAG
-            + ": edit a specialist in the address book. \n"
+            + ": Edit a specialist in the address book. \n"
             + MESSAGE_USAGE_GENERAL
             + PREFIX_LOCATION + "LOCATION "
             + PREFIX_SPECIALTY + "SPECIALTY \n"
             + "Example: " + COMMAND_WORD + " "
-            + SPECIALIST_TAG + " "
             + PERSON_EXAMPLE
             + PREFIX_LOCATION + "311, Clementi Ave 2, #02-25 "
             + PREFIX_SPECIALTY + "Physiotherapist ";

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -49,7 +49,6 @@ public class FindCommand extends Command {
             + "Example: " + COMMAND_WORD + " "
             + PATIENT_TAG + " "
             + PERSON_EXAMPLE
-            + PREFIX_TAG + "owesMoney "
             + PREFIX_AGE + "30 "
             + PREFIX_MEDICALHISTORY + "Osteoporosis";
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -103,6 +103,17 @@ public class AddressBookParser {
             case ListCommand.COMMAND_WORD:
                 return new ListCommand(personType);
 
+            case EditCommand.COMMAND_WORD:
+                if (model.getSelectedPerson() instanceof Patient) {
+                    throw new ParseException(
+                            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE_PATIENT));
+                }
+                if (model.getSelectedPerson() instanceof Specialist) {
+                    throw new ParseException(
+                            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE_SPECIALIST));
+                }
+                break;
+
             default:
                 logger.finer("This user input caused a ParseException: " + userInput);
                 throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -28,7 +28,9 @@ import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
+import seedu.address.model.person.Patient;
 import seedu.address.model.person.PersonType;
+import seedu.address.model.person.Specialist;
 
 /**
  * Parses user input.
@@ -95,9 +97,6 @@ public class AddressBookParser {
             case AddCommand.COMMAND_WORD:
                 return new AddCommandParser().parse(personType, arguments);
 
-            case EditCommand.COMMAND_WORD:
-                return new EditCommandParser().parse(personType, arguments);
-
             case FindCommand.COMMAND_WORD:
                 return new FindCommandParser().parse(personType, arguments);
 
@@ -119,6 +118,14 @@ public class AddressBookParser {
             logger.fine("Command word: " + commandWord + "; Arguments: " + arguments);
 
             switch (commandWord) {
+            case EditCommand.COMMAND_WORD:
+                if (model.getSelectedPerson() instanceof Patient) {
+                    return new EditCommandParser().parse(PersonType.PATIENT, arguments);
+                }
+                if (model.getSelectedPerson() instanceof Specialist) {
+                    return new EditCommandParser().parse(PersonType.SPECIALIST, arguments);
+                }
+                break;
 
             case DeleteCommand.COMMAND_WORD:
                 return new DeleteCommandParser().parse(arguments);
@@ -148,7 +155,6 @@ public class AddressBookParser {
                 return new RedoCommand();
 
             case AddCommand.COMMAND_WORD:
-            case EditCommand.COMMAND_WORD:
             case FindCommand.COMMAND_WORD:
             case ListCommand.COMMAND_WORD:
                 throw new ParseException(MESSAGE_INVALID_PERSON_TYPE);

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -56,8 +56,7 @@ public class EditCommandParser implements ParserComplex<EditCommand> {
                     EditCommand.MESSAGE_USAGE_PATIENT));
         }
 
-        if (argMultimap.anyValuesBlank(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                PREFIX_TAG, PREFIX_AGE, PREFIX_MEDICALHISTORY)) {
+        if (argMultimap.anyValuesBlank(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_AGE)) {
             throw new ParseException(String.format(MESSAGE_BLANK_ARGUMENTS,
                     EditCommand.MESSAGE_USAGE_PATIENT));
         }
@@ -91,8 +90,7 @@ public class EditCommandParser implements ParserComplex<EditCommand> {
                     EditCommand.MESSAGE_USAGE_SPECIALIST));
         }
 
-        if (argMultimap.anyValuesBlank(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_LOCATION,
-                PREFIX_TAG, PREFIX_SPECIALTY)) {
+        if (argMultimap.anyValuesBlank(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_LOCATION, PREFIX_SPECIALTY)) {
             throw new ParseException(String.format(MESSAGE_BLANK_ARGUMENTS,
                     EditCommand.MESSAGE_USAGE_SPECIALIST));
         }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_BLANK_ARGUMENTS;
 import static seedu.address.logic.Messages.MESSAGE_ERROR_STATE;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_AGE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
@@ -19,6 +21,7 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPatientDescriptor;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.EditCommand.EditSpecialistDescriptor;
+import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.MedicalHistory;
 import seedu.address.model.person.PersonType;
@@ -49,6 +52,17 @@ public class EditCommandParser implements ParserComplex<EditCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                         PREFIX_TAG, PREFIX_AGE, PREFIX_MEDICALHISTORY);
 
+        if (!argMultimap.getPreamble().isBlank() && !args.isBlank()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditCommand.MESSAGE_USAGE_PATIENT));
+        }
+
+        if (argMultimap.anyValuesBlank(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+                PREFIX_TAG, PREFIX_AGE, PREFIX_MEDICALHISTORY)) {
+            throw new ParseException(String.format(MESSAGE_BLANK_ARGUMENTS,
+                    EditCommand.MESSAGE_USAGE_PATIENT));
+        }
+
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                 PREFIX_AGE);
 
@@ -72,6 +86,17 @@ public class EditCommandParser implements ParserComplex<EditCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_LOCATION,
                         PREFIX_TAG, PREFIX_SPECIALTY);
+
+        if (!argMultimap.getPreamble().isBlank() && !args.isBlank()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditCommand.MESSAGE_USAGE_SPECIALIST));
+        }
+
+        if (argMultimap.anyValuesBlank(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_LOCATION,
+                PREFIX_TAG, PREFIX_SPECIALTY)) {
+            throw new ParseException(String.format(MESSAGE_BLANK_ARGUMENTS,
+                    EditCommand.MESSAGE_USAGE_SPECIALIST));
+        }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                 PREFIX_LOCATION, PREFIX_SPECIALTY);

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -21,7 +21,6 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPatientDescriptor;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.EditCommand.EditSpecialistDescriptor;
-import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.MedicalHistory;
 import seedu.address.model.person.PersonType;

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -17,9 +17,9 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPatientDescriptor;
+import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.EditCommand.EditSpecialistDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.MedicalHistory;
@@ -49,32 +49,14 @@ public class EditCommandParser implements ParserComplex<EditCommand> {
 
     private EditCommand parsePatient(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                         PREFIX_TAG, PREFIX_AGE, PREFIX_MEDICALHISTORY);
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                 PREFIX_AGE);
 
-        Index index;
-        try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    EditCommand.MESSAGE_USAGE_PATIENT), pe);
-        }
-
-        EditPatientDescriptor editPatientDescriptor = new EditPatientDescriptor();
-
-        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            editPatientDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
-        }
-        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
-            editPatientDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));
-        }
-        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
-            editPatientDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
-        }
+        EditPersonDescriptor editPersonDescriptor = parseCommonPersonForEdit(argMultimap);
+        EditPatientDescriptor editPatientDescriptor = (EditPatientDescriptor) editPersonDescriptor;
 
         if (argMultimap.getValue(PREFIX_AGE).isPresent()) {
             editPatientDescriptor.setAge(ParserUtil.parseAge(argMultimap
@@ -82,13 +64,13 @@ public class EditCommandParser implements ParserComplex<EditCommand> {
         }
         parseMedicalHistoriesForEdit(argMultimap.getAllValues(PREFIX_MEDICALHISTORY))
                 .ifPresent(editPatientDescriptor::setMedicalHistory);
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPatientDescriptor::setTags);
 
         if (!editPatientDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
         }
-        return new EditCommand(index, editPatientDescriptor);
+        return new EditCommand(editPatientDescriptor);
     }
+
     private EditCommand parseSpecialist(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_LOCATION,
@@ -97,25 +79,9 @@ public class EditCommandParser implements ParserComplex<EditCommand> {
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                 PREFIX_LOCATION, PREFIX_SPECIALTY);
 
-        Index index;
-        try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    EditCommand.MESSAGE_USAGE_SPECIALIST), pe);
-        }
+        EditPersonDescriptor editPersonDescriptor = parseCommonPersonForEdit(argMultimap);
+        EditSpecialistDescriptor editSpecialistDescriptor = (EditSpecialistDescriptor) editPersonDescriptor;
 
-        EditSpecialistDescriptor editSpecialistDescriptor = new EditSpecialistDescriptor();
-
-        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            editSpecialistDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
-        }
-        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
-            editSpecialistDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));
-        }
-        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
-            editSpecialistDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
-        }
         if (argMultimap.getValue(PREFIX_LOCATION).isPresent()) {
             editSpecialistDescriptor.setLocation(ParserUtil.parseLocation(argMultimap.getValue(PREFIX_LOCATION).get()));
         }
@@ -123,12 +89,27 @@ public class EditCommandParser implements ParserComplex<EditCommand> {
             editSpecialistDescriptor.setSpecialty(ParserUtil.parseSpecialty(
                     argMultimap.getValue(PREFIX_SPECIALTY).get()));
         }
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editSpecialistDescriptor::setTags);
 
         if (!editSpecialistDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
         }
-        return new EditCommand(index, editSpecialistDescriptor);
+        return new EditCommand(editSpecialistDescriptor);
+    }
+
+
+    private EditPersonDescriptor parseCommonPersonForEdit(ArgumentMultimap argMultimap) throws ParseException {
+        EditPersonDescriptor editPersonDescriptor = new EditPatientDescriptor();
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            editPersonDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
+        }
+        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
+            editPersonDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
+            editPersonDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
+        }
+        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
+        return editPersonDescriptor;
     }
 
     /**
@@ -155,7 +136,6 @@ public class EditCommandParser implements ParserComplex<EditCommand> {
     private Optional<Set<MedicalHistory>> parseMedicalHistoriesForEdit(Collection<String> medicalHistories)
             throws ParseException {
         assert medicalHistories != null;
-
         if (medicalHistories.isEmpty()) {
             return Optional.empty();
         }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -1,8 +1,6 @@
 package seedu.address.logic.parser;
 
-import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_TYPE;
+import static seedu.address.logic.Messages.MESSAGE_ERROR_STATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_AGE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
@@ -37,14 +35,13 @@ public class EditCommandParser implements ParserComplex<EditCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public EditCommand parse(PersonType personType, String args) throws ParseException {
-        requireNonNull(args);
         if (personType.equals(PersonType.PATIENT)) {
             return parsePatient(args);
-        } else if (personType.equals(PersonType.SPECIALIST)) {
-            return parseSpecialist(args);
-        } else {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_INVALID_PERSON_TYPE));
         }
+        if (personType.equals(PersonType.SPECIALIST)) {
+            return parseSpecialist(args);
+        }
+        throw new ParseException(MESSAGE_ERROR_STATE);
     }
 
     private EditCommand parsePatient(String args) throws ParseException {
@@ -55,8 +52,8 @@ public class EditCommandParser implements ParserComplex<EditCommand> {
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                 PREFIX_AGE);
 
-        EditPersonDescriptor editPersonDescriptor = parseCommonPersonForEdit(argMultimap);
-        EditPatientDescriptor editPatientDescriptor = (EditPatientDescriptor) editPersonDescriptor;
+        EditPatientDescriptor editPatientDescriptor = new EditPatientDescriptor();
+        parseCommonPersonForEdit(editPatientDescriptor, argMultimap);
 
         if (argMultimap.getValue(PREFIX_AGE).isPresent()) {
             editPatientDescriptor.setAge(ParserUtil.parseAge(argMultimap
@@ -79,8 +76,8 @@ public class EditCommandParser implements ParserComplex<EditCommand> {
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                 PREFIX_LOCATION, PREFIX_SPECIALTY);
 
-        EditPersonDescriptor editPersonDescriptor = parseCommonPersonForEdit(argMultimap);
-        EditSpecialistDescriptor editSpecialistDescriptor = (EditSpecialistDescriptor) editPersonDescriptor;
+        EditSpecialistDescriptor editSpecialistDescriptor = new EditSpecialistDescriptor();
+        parseCommonPersonForEdit(editSpecialistDescriptor, argMultimap);
 
         if (argMultimap.getValue(PREFIX_LOCATION).isPresent()) {
             editSpecialistDescriptor.setLocation(ParserUtil.parseLocation(argMultimap.getValue(PREFIX_LOCATION).get()));
@@ -96,9 +93,12 @@ public class EditCommandParser implements ParserComplex<EditCommand> {
         return new EditCommand(editSpecialistDescriptor);
     }
 
-
-    private EditPersonDescriptor parseCommonPersonForEdit(ArgumentMultimap argMultimap) throws ParseException {
-        EditPersonDescriptor editPersonDescriptor = new EditPatientDescriptor();
+    /**
+     * Creates an {@code EditPersonDescriptor} by checking if each attribute of a {@code Person}
+     * is present within the user input arguments.
+     */
+    private EditPersonDescriptor parseCommonPersonForEdit(EditPersonDescriptor editPersonDescriptor,
+                                                          ArgumentMultimap argMultimap) throws ParseException {
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             editPersonDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
         }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -12,7 +12,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SPECIALTY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -116,12 +115,10 @@ public class FindCommandParser implements ParserComplex<FindCommand> {
     }
 
     private List<String> splitKeywordsByWhitespace(ArgumentMultimap argMultimap, Prefix prefix) {
-        if (argMultimap.getValue(prefix).isPresent()) {
-            String trimmedArgs = argMultimap.getValue(prefix).get().trim();
-            String[] keywords = trimmedArgs.split("\\s+");
-            return Arrays.asList(keywords);
-        }
-        return new ArrayList<>();
+        assert argMultimap.getValue(prefix).isPresent();
+        String trimmedArgs = argMultimap.getValue(prefix).get().trim();
+        String[] keywords = trimmedArgs.split("\\s+");
+        return Arrays.asList(keywords);
     }
 
     private FindPredicateMap setupPersonPredicates(ArgumentMultimap argMultimap) {

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -141,13 +141,13 @@ public class CommandTestUtil {
      * - the CommandException message matches {@code expectedMessage} <br>
      * - the address book, filtered person list and selected person in {@code actualModel} remain unchanged
      */
+    @SuppressWarnings("checkstyle:EmptyCatchBlock")
     public static void assertCommandFailure(Command command, Model actualModel,
                                             String expectedMessage, CommandHistory commandHistory) {
         // we are unable to defensively copy the model for comparison later, so we can
         // only do so by copying its components.
         AddressBook expectedAddressBook = new AddressBook(actualModel.getAddressBook());
         List<Person> expectedFilteredList = new ArrayList<>(actualModel.getFilteredPersonList());
-
         assertThrows(CommandException.class, expectedMessage, () -> command.execute(actualModel, commandHistory));
         assertEquals(expectedAddressBook, actualModel.getAddressBook());
         assertEquals(expectedFilteredList, actualModel.getFilteredPersonList());

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -11,7 +11,6 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -22,7 +21,6 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.EditCommand.EditPatientDescriptor;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -31,15 +29,12 @@ import seedu.address.model.person.Patient;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.PersonType;
 import seedu.address.model.person.Specialist;
-import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.testutil.EditPatientDescriptorBuilder;
 import seedu.address.testutil.EditSpecialistDescriptorBuilder;
 import seedu.address.testutil.PatientBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.SpecialistBuilder;
 
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for EditCommand.

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -48,7 +48,7 @@ public class EditCommandTest {
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
         Patient editedPatient = new PatientBuilder().build();
         EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder(editedPatient).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+        EditCommand editCommand = new EditCommand(descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPatient));
 
@@ -70,7 +70,7 @@ public class EditCommandTest {
 
         EditPersonDescriptor descriptor = new EditSpecialistDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_HUSBAND).build();
-        EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
+        EditCommand editCommand = new EditCommand(descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
@@ -84,7 +84,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPatientDescriptor());
+        EditCommand editCommand = new EditCommand(new EditPatientDescriptor());
         Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
@@ -100,8 +100,7 @@ public class EditCommandTest {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
         Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person editedPerson = new PatientBuilder((Patient) personInFilteredList).withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
-                new EditPatientDescriptorBuilder().withName(VALID_NAME_BOB).build());
+        EditCommand editCommand = new EditCommand(new EditPatientDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
@@ -118,7 +117,7 @@ public class EditCommandTest {
         Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         CommandHistory commandHistory = new CommandHistory();
         EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder((Patient) firstPerson).build();
-        EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
+        EditCommand editCommand = new EditCommand(descriptor);
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON, commandHistory);
     }
@@ -129,19 +128,9 @@ public class EditCommandTest {
 
         // edit person in filtered list into a duplicate in address book
         Person personInList = model.getAddressBook().getPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
-                new EditPatientDescriptorBuilder((Patient) personInList).build());
+        EditCommand editCommand = new EditCommand(new EditPatientDescriptorBuilder((Patient) personInList).build());
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON, commandHistory);
-    }
-
-    @Test
-    public void execute_invalidPersonIndexUnfilteredList_failure() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
-        EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder().withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
-
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, commandHistory);
     }
 
     /**
@@ -155,19 +144,18 @@ public class EditCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
-        EditCommand editCommand = new EditCommand(outOfBoundIndex,
-                new EditPatientDescriptorBuilder().withName(VALID_NAME_BOB).build());
+        EditCommand editCommand = new EditCommand(new EditPatientDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, commandHistory);
     }
 
     @Test
     public void equals() {
-        final EditCommand standardCommand = new EditCommand(INDEX_FIRST_PERSON, DESC_AMY);
+        final EditCommand standardCommand = new EditCommand(DESC_AMY);
 
         // same values -> returns true
-        EditPersonDescriptor copyDescriptor = new EditPatientDescriptor((EditPatientDescriptor) DESC_AMY);
-        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST_PERSON, copyDescriptor);
+        EditPersonDescriptor copyDescriptor = new EditPatientDescriptor(DESC_AMY);
+        EditCommand commandWithSameValues = new EditCommand(copyDescriptor);
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
@@ -179,19 +167,15 @@ public class EditCommandTest {
         // different types -> returns false
         assertFalse(standardCommand.equals(new ClearCommand()));
 
-        // different index -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_PERSON, DESC_AMY)));
-
         // different descriptor -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_PERSON, DESC_BOB)));
+        assertFalse(standardCommand.equals(new EditCommand(DESC_BOB)));
     }
 
     @Test
     public void toStringMethod() {
-        Index index = Index.fromOneBased(1);
         EditPersonDescriptor editPersonDescriptor = new EditPatientDescriptor();
-        EditCommand editCommand = new EditCommand(index, editPersonDescriptor);
-        String expected = EditCommand.class.getCanonicalName() + "{index=" + index + ", editPersonDescriptor="
+        EditCommand editCommand = new EditCommand(editPersonDescriptor);
+        String expected = EditCommand.class.getCanonicalName() + "{editPersonDescriptor="
                 + editPersonDescriptor + "}";
         assertEquals(expected, editCommand.toString());
     }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -8,8 +8,10 @@ import static seedu.address.logic.commands.CommandTestUtil.COMMANDWORD_DESC_VALI
 import static seedu.address.logic.commands.CommandTestUtil.COMMAND_WORD_1;
 import static seedu.address.logic.commands.CommandTestUtil.SHORTCUT_ALIAS_1;
 import static seedu.address.logic.commands.CommandTestUtil.SHORTCUT_DESC_VALID;
+import static seedu.address.logic.parser.CliSyntax.PATIENT_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.SPECIALIST_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -126,6 +128,29 @@ public class AddressBookParserTest {
                 + " " + SpecialistUtil.getEditSpecialistDescriptorDetails(descriptor);
         EditCommand command = (EditCommand) parser.parseCommand(input);
         assertEquals(new EditCommand(descriptor), command);
+    }
+
+    @Test
+    public void parseCommand_complexEdit_failure() {
+        Patient patient = (Patient) new PatientBuilder()
+                .withMedicalHistory("MedHistory1")
+                .withTags("Tag1", "Tag2")
+                .build();
+        Specialist specialist = (Specialist) new SpecialistBuilder()
+                .withSpecialty("TestSpecialty")
+                .withLocation("TestLocation")
+                .withTags("Tag1", "Tag2")
+                .build();
+        String userInput1 = EditCommand.COMMAND_WORD + " " + PATIENT_TAG;
+        String userInput2 = EditCommand.COMMAND_WORD + " " + SPECIALIST_TAG;
+
+        model.updateSelectedPerson(patient);
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                EditCommand.MESSAGE_USAGE_PATIENT), () -> parser.parseCommand(userInput1));
+
+        model.updateSelectedPerson(specialist);
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                EditCommand.MESSAGE_USAGE_SPECIALIST), () -> parser.parseCommand(userInput2));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -36,6 +36,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.person.Patient;
 import seedu.address.model.person.PersonType;
@@ -50,8 +51,8 @@ import seedu.address.testutil.SpecialistBuilder;
 import seedu.address.testutil.SpecialistUtil;
 
 public class AddressBookParserTest {
-
-    private final AddressBookParser parser = new AddressBookParser(new ModelManager());
+    private final Model model = new ModelManager();
+    private final AddressBookParser parser = new AddressBookParser(model);
 
     @Test
     public void parseCommand_addShortcut() throws Exception {
@@ -101,22 +102,29 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_edit_patient() throws Exception {
-        Patient patient = new PatientBuilder().build();
+        Patient patient = (Patient) new PatientBuilder()
+                .withMedicalHistory("MedHistory1")
+                .withTags("Tag1", "Tag2")
+                .build();
+        model.updateSelectedPerson(patient);
         EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder(patient).build();
-        EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD
-                + " " + CliSyntax.PATIENT_TAG + " "
-                + INDEX_FIRST_PERSON.getOneBased() + " " + PatientUtil.getEditPatientDescriptorDetails(descriptor));
+        String input = EditCommand.COMMAND_WORD + " " + PatientUtil.getEditPatientDescriptorDetails(descriptor);
+        EditCommand command = (EditCommand) parser.parseCommand(input);
         assertEquals(new EditCommand(descriptor), command);
     }
 
     @Test
     public void parseCommand_edit_specialist() throws Exception {
-        Specialist person = new SpecialistBuilder().build();
-        EditSpecialistDescriptor descriptor = new EditSpecialistDescriptorBuilder(person).build();
-        EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD
-                + " " + CliSyntax.SPECIALIST_TAG + " "
-                + INDEX_FIRST_PERSON.getOneBased()
-                + " " + SpecialistUtil.getEditSpecialistDescriptorDetails(descriptor));
+        Specialist specialist = (Specialist) new SpecialistBuilder()
+                .withSpecialty("TestSpecialty")
+                .withLocation("TestLocation")
+                .withTags("Tag1", "Tag2")
+                .build();
+        model.updateSelectedPerson(specialist);
+        EditSpecialistDescriptor descriptor = new EditSpecialistDescriptorBuilder(specialist).build();
+        String input = EditCommand.COMMAND_WORD
+                + " " + SpecialistUtil.getEditSpecialistDescriptorDetails(descriptor);
+        EditCommand command = (EditCommand) parser.parseCommand(input);
         assertEquals(new EditCommand(descriptor), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -106,7 +106,7 @@ public class AddressBookParserTest {
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD
                 + " " + CliSyntax.PATIENT_TAG + " "
                 + INDEX_FIRST_PERSON.getOneBased() + " " + PatientUtil.getEditPatientDescriptorDetails(descriptor));
-        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
+        assertEquals(new EditCommand(descriptor), command);
     }
 
     @Test
@@ -117,7 +117,7 @@ public class AddressBookParserTest {
                 + " " + CliSyntax.SPECIALIST_TAG + " "
                 + INDEX_FIRST_PERSON.getOneBased()
                 + " " + SpecialistUtil.getEditSpecialistDescriptorDetails(descriptor));
-        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
+        assertEquals(new EditCommand(descriptor), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -17,6 +17,7 @@ import static seedu.address.logic.commands.CommandTestUtil.SPECIALTY_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LOCATION_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
@@ -28,11 +29,13 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseBasicSuccess;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseComplexFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseComplexSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
@@ -40,13 +43,22 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Patient;
+import seedu.address.model.person.Person;
 import seedu.address.model.person.PersonType;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.Specialist;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.EditPatientDescriptorBuilder;
 import seedu.address.testutil.EditSpecialistDescriptorBuilder;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class EditCommandParserTest {
 
@@ -59,17 +71,12 @@ public class EditCommandParserTest {
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE_PATIENT);
 
     private EditCommandParser parser = new EditCommandParser();
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void parse_missingParts_failure() {
-        // no index specified
-        assertParseComplexFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_SPECIALIST, PersonType.SPECIALIST);
-
         // no field specified
-        assertParseComplexFailure(parser, "1", EditCommand.MESSAGE_NOT_EDITED, PersonType.SPECIALIST);
-
-        // no index and no field specified
-        assertParseComplexFailure(parser, "", MESSAGE_INVALID_SPECIALIST, PersonType.SPECIALIST);
+        assertParseComplexFailure(parser, "", EditCommand.MESSAGE_NOT_EDITED, PersonType.SPECIALIST);
     }
 
     @Test
@@ -89,38 +96,37 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
-        assertParseComplexFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS,
+        assertParseComplexFailure(parser, INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS,
                 PersonType.PATIENT); // invalid name
-        assertParseComplexFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS,
+        assertParseComplexFailure(parser, INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS,
                 PersonType.PATIENT); // invalid phone
-        assertParseComplexFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS,
+        assertParseComplexFailure(parser, INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS,
                 PersonType.PATIENT); // invalid email
-        assertParseComplexFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS,
+        assertParseComplexFailure(parser, INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS,
                 PersonType.PATIENT); // invalid tag
 
         // invalid phone followed by valid email
-        assertParseComplexFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS,
+        assertParseComplexFailure(parser, INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS,
                 PersonType.PATIENT);
 
         // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Person} being edited,
         // parsing it together with a valid tag results in error
-        assertParseComplexFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY,
+        assertParseComplexFailure(parser, TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY,
                 Tag.MESSAGE_CONSTRAINTS, PersonType.PATIENT);
-        assertParseComplexFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND,
+        assertParseComplexFailure(parser, TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND,
                 Tag.MESSAGE_CONSTRAINTS, PersonType.PATIENT);
-        assertParseComplexFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND,
+        assertParseComplexFailure(parser, TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND,
                 Tag.MESSAGE_CONSTRAINTS, PersonType.PATIENT);
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseComplexFailure(parser,
-                "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_PHONE_AMY,
+                INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_PHONE_AMY,
                 Name.MESSAGE_CONSTRAINTS, PersonType.PATIENT);
     }
 
     @Test
     public void parse_allFieldsSpecified_success() {
-        Index targetIndex = INDEX_SECOND_PERSON;
-        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + TAG_DESC_HUSBAND
+        String userInput = PHONE_DESC_BOB + TAG_DESC_HUSBAND
                 + EMAIL_DESC_AMY + LOCATION_DESC_AMY + NAME_DESC_AMY + TAG_DESC_FRIEND + SPECIALTY_DESC_BOB;
 
         EditPersonDescriptor descriptor = new EditSpecialistDescriptorBuilder()
@@ -134,42 +140,47 @@ public class EditCommandParserTest {
     }
 
     @Test
-    public void parse_someFieldsSpecified_success() {
-        Index targetIndex = INDEX_FIRST_PERSON;
-        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + EMAIL_DESC_AMY;
-
-        EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder().withPhone(VALID_PHONE_BOB)
-                .withEmail(VALID_EMAIL_AMY).build();
+    public void parse_somePersonFieldsSpecified_success() {
+        // Specialists are used in this test to check Person Fields.
+        String userInputArgs = PHONE_DESC_BOB + EMAIL_DESC_BOB;
+        EditPersonDescriptor descriptor = new EditCommand.EditSpecialistDescriptor();
+        descriptor.setPhone(new Phone(VALID_PHONE_BOB));
+        descriptor.setEmail(new Email(VALID_EMAIL_BOB));
         EditCommand expectedCommand = new EditCommand(descriptor);
 
-        assertParseComplexSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
+        assertParseComplexSuccess(parser, userInputArgs, expectedCommand, PersonType.SPECIALIST);
     }
 
     @Test
     public void parse_oneFieldSpecified_success() {
         // name
-        Index targetIndex = INDEX_THIRD_PERSON;
-        String userInput = targetIndex.getOneBased() + NAME_DESC_AMY;
-        EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder().withName(VALID_NAME_AMY).build();
+        String userInput = NAME_DESC_AMY;
+        EditPersonDescriptor descriptor = new EditCommand.EditPatientDescriptor();
+        descriptor.setName(new Name(VALID_NAME_AMY));
         EditCommand expectedCommand = new EditCommand(descriptor);
         assertParseComplexSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
 
         // phone
-        userInput = targetIndex.getOneBased() + PHONE_DESC_AMY;
-        descriptor = new EditPatientDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
+        userInput = PHONE_DESC_AMY;
+        descriptor = new EditCommand.EditPatientDescriptor();
+        descriptor.setPhone(new Phone(VALID_PHONE_AMY));
         expectedCommand = new EditCommand(descriptor);
         assertParseComplexSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
 
         // email
-        userInput = targetIndex.getOneBased() + EMAIL_DESC_AMY;
-        descriptor = new EditPatientDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();
+        userInput = EMAIL_DESC_AMY;
+        descriptor = new EditCommand.EditPatientDescriptor();
+        descriptor.setEmail(new Email(VALID_EMAIL_AMY));
         expectedCommand = new EditCommand(descriptor);
         assertParseComplexSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
 
         // tags
-        userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND;
-        descriptor = new EditPatientDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();
-        expectedCommand = new EditCommand( descriptor);
+        userInput = TAG_DESC_FRIEND;
+        descriptor = new EditCommand.EditPatientDescriptor();
+        Set<Tag> testTags = new HashSet<>();
+        testTags.add(new Tag(VALID_TAG_FRIEND));
+        descriptor.setTags(testTags);
+        expectedCommand = new EditCommand(descriptor);
         assertParseComplexSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
     }
 
@@ -179,20 +190,19 @@ public class EditCommandParserTest {
         // AddCommandParserTest#parse_repeatedNonTagValue_failure()
 
         // valid followed by invalid
-        Index targetIndex = INDEX_FIRST_PERSON;
-        String userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + PHONE_DESC_BOB;
+        String userInput = INVALID_PHONE_DESC + PHONE_DESC_BOB;
 
         assertParseComplexFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE),
                 PersonType.SPECIALIST);
 
         // invalid followed by valid
-        userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + INVALID_PHONE_DESC;
+        userInput = PHONE_DESC_BOB + INVALID_PHONE_DESC;
 
         assertParseComplexFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE),
                 PersonType.SPECIALIST);
 
         // mulltiple valid fields repeated
-        userInput = targetIndex.getOneBased() + PHONE_DESC_AMY + LOCATION_DESC_AMY + EMAIL_DESC_AMY
+        userInput = PHONE_DESC_AMY + LOCATION_DESC_AMY + EMAIL_DESC_AMY
                 + TAG_DESC_FRIEND + PHONE_DESC_AMY + LOCATION_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
                 + PHONE_DESC_BOB + LOCATION_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;
 
@@ -201,22 +211,29 @@ public class EditCommandParserTest {
                 PersonType.SPECIALIST);
 
         // multiple invalid values
-        userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + INVALID_LOCATION_DESC + INVALID_EMAIL_DESC
-                + INVALID_PHONE_DESC + INVALID_LOCATION_DESC + INVALID_EMAIL_DESC;
+        userInput = INVALID_PHONE_DESC + INVALID_EMAIL_DESC + INVALID_PHONE_DESC + INVALID_EMAIL_DESC;
 
         assertParseComplexFailure(parser, userInput,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_LOCATION),
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL),
                 PersonType.SPECIALIST);
     }
 
     @Test
     public void parse_resetTags_success() {
-        Index targetIndex = INDEX_THIRD_PERSON;
-        String userInput = targetIndex.getOneBased() + TAG_EMPTY;
+        Patient firstPerson = (Patient) model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        model.updateSelectedPerson(firstPerson);
 
-        EditPersonDescriptor descriptor = new EditSpecialistDescriptorBuilder().withTags().build();
+        String userInputArgs = TAG_EMPTY;
+
+        // Expected edit command for clearing tags
+        EditCommand.EditPatientDescriptor descriptor = new EditCommand.EditPatientDescriptor();
+        descriptor.setTags(new HashSet<Tag>());
         EditCommand expectedCommand = new EditCommand(descriptor);
 
-        assertParseComplexSuccess(parser, userInput, expectedCommand, PersonType.SPECIALIST);
+        PersonType personType = model.getSelectedPerson() instanceof Patient
+                ? PersonType.PATIENT
+                : PersonType.SPECIALIST;
+
+        assertParseComplexSuccess(parser, userInputArgs, expectedCommand, personType);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_BLANK_ARGUMENTS;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
@@ -24,8 +25,10 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SPECIALTY_DERMATOLOGY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_AGE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseComplexFailure;
@@ -55,6 +58,11 @@ import seedu.address.testutil.EditSpecialistDescriptorBuilder;
 public class EditCommandParserTest {
 
     private static final String TAG_EMPTY = " " + PREFIX_TAG;
+    private static final String NAME_EMPTY = " " + PREFIX_NAME;
+    private static final String PHONE_EMPTY = " " + PREFIX_PHONE;
+    private static final String AGE_EMPTY = " " + PREFIX_AGE;
+    private static final String LOCATION_EMPTY = " " + PREFIX_LOCATION;
+
 
     private static final String MESSAGE_INVALID_SPECIALIST =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE_SPECIALIST);
@@ -227,5 +235,21 @@ public class EditCommandParserTest {
                 : PersonType.SPECIALIST;
 
         assertParseComplexSuccess(parser, userInputArgs, expectedCommand, personType);
+    }
+
+    @Test
+    public void parse_emptyPrefixArguments_failure() {
+        String userInputArgs = NAME_EMPTY + PHONE_EMPTY;
+        String expectedMessage = String.format(MESSAGE_BLANK_ARGUMENTS,
+                EditCommand.MESSAGE_USAGE_PATIENT);
+        assertParseComplexFailure(parser, userInputArgs, expectedMessage, PersonType.PATIENT);
+
+        userInputArgs = AGE_EMPTY;
+        assertParseComplexFailure(parser, userInputArgs, expectedMessage, PersonType.PATIENT);
+
+        expectedMessage = String.format(MESSAGE_BLANK_ARGUMENTS,
+                EditCommand.MESSAGE_USAGE_SPECIALIST);
+        userInputArgs = LOCATION_EMPTY;
+        assertParseComplexFailure(parser, userInputArgs, expectedMessage, PersonType.SPECIALIST);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -4,7 +4,6 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_LOCATION_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
@@ -29,17 +28,16 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.logic.parser.CommandParserTestUtil.assertParseBasicSuccess;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseComplexFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseComplexSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
@@ -49,16 +47,10 @@ import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Patient;
-import seedu.address.model.person.Person;
 import seedu.address.model.person.PersonType;
 import seedu.address.model.person.Phone;
-import seedu.address.model.person.Specialist;
 import seedu.address.model.tag.Tag;
-import seedu.address.testutil.EditPatientDescriptorBuilder;
 import seedu.address.testutil.EditSpecialistDescriptorBuilder;
-
-import java.util.HashSet;
-import java.util.Set;
 
 public class EditCommandParserTest {
 

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -128,7 +128,7 @@ public class EditCommandParserTest {
                 .withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY)
                 .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(descriptor);
 
         assertParseComplexSuccess(parser, userInput, expectedCommand, PersonType.SPECIALIST);
     }
@@ -140,7 +140,7 @@ public class EditCommandParserTest {
 
         EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder().withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_AMY).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(descriptor);
 
         assertParseComplexSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
     }
@@ -151,25 +151,25 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_THIRD_PERSON;
         String userInput = targetIndex.getOneBased() + NAME_DESC_AMY;
         EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder().withName(VALID_NAME_AMY).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(descriptor);
         assertParseComplexSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
 
         // phone
         userInput = targetIndex.getOneBased() + PHONE_DESC_AMY;
         descriptor = new EditPatientDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditCommand(descriptor);
         assertParseComplexSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
 
         // email
         userInput = targetIndex.getOneBased() + EMAIL_DESC_AMY;
         descriptor = new EditPatientDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditCommand(descriptor);
         assertParseComplexSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
 
         // tags
         userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND;
         descriptor = new EditPatientDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditCommand( descriptor);
         assertParseComplexSuccess(parser, userInput, expectedCommand, PersonType.PATIENT);
     }
 
@@ -215,7 +215,7 @@ public class EditCommandParserTest {
         String userInput = targetIndex.getOneBased() + TAG_EMPTY;
 
         EditPersonDescriptor descriptor = new EditSpecialistDescriptorBuilder().withTags().build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(descriptor);
 
         assertParseComplexSuccess(parser, userInput, expectedCommand, PersonType.SPECIALIST);
     }

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -1,5 +1,6 @@
 package seedu.address.testutil;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -61,6 +62,15 @@ public abstract class EditPersonDescriptorBuilder {
     public EditPersonDescriptorBuilder withTags(String... tags) {
         Set<Tag> tagSet = Stream.of(tags).map(Tag::new).collect(Collectors.toSet());
         descriptor.setTags(tagSet);
+        return this;
+    }
+
+    /**
+     * Parses the {@code tag} into an empty {@code Set<tag>} and set it to the {@code EditPersonDescriptor}
+     * that we are building.
+     */
+    public EditPersonDescriptorBuilder withEmptyTags() {
+        descriptor.setTags(new HashSet<Tag>());
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/SpecialistUtil.java
+++ b/src/test/java/seedu/address/testutil/SpecialistUtil.java
@@ -56,11 +56,7 @@ public class SpecialistUtil {
                 .append(" "));
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
-            if (tags.isEmpty()) {
-                sb.append(PREFIX_TAG);
-            } else {
-                tags.forEach(s -> sb.append(PREFIX_TAG).append(s.tagName).append(" "));
-            }
+            tags.forEach(s -> sb.append(PREFIX_TAG).append(s.tagName).append(" "));
         }
         return sb.toString();
     }


### PR DESCRIPTION
# Overview 
Tackles #63 

## Changes
- `edit` command now edits the person in the view panel only. 
- `edit` command now does not require a `PersonType` tag. The parser will check the `PersonType` of the person being viewed and handle accordingly.
- Fix a bug where locations for specialists were not being considered when checking if a person is being edited.
- Added and modified some new error messages for `edit` and `find` command.

## Notes:
I have added/modified relevant test cases for the new `edit` command. Code Cov a bit strict :(