### PR TITLE
Handle duplicate commands properly when recalling commands

### DIFF
--- a/src/main/java/seedu/address/model/CommandStringStash.java
+++ b/src/main/java/seedu/address/model/CommandStringStash.java
@@ -71,8 +71,13 @@ public class CommandStringStash {
     public void addCommandString(String commandInputString) {
         assert commandInputString != null;
 
+        // remove existing command String from stack if it already exists as it will be replaced by new command
+        if (cmdStringStack.contains(commandInputString)) {
+            cmdStringStack.remove(commandInputString);
+        }
+
         // evict least recently added command string if necessary
-        if (this.cmdStringStack.size() == 20) {
+        if (cmdStringStack.size() == 20) {
             cmdStringStack.remove(0);
         }
 

--- a/src/test/java/seedu/address/model/CommandStringStashTest.java
+++ b/src/test/java/seedu/address/model/CommandStringStashTest.java
@@ -48,6 +48,18 @@ public class CommandStringStashTest {
     }
 
     @Test
+    public void addCommandString_withDuplicateCommandString_removesOldInstance() {
+        CommandStringStash commandStringStash = new CommandStringStash(createCmdStringStackIntegers(0, 9), 6);
+        List<String> expectedCommandStringStack = createCmdStringStackIntegers(0, 3);
+        expectedCommandStringStack.addAll(createCmdStringStackIntegers(5, 9));
+        expectedCommandStringStack.add("4");
+        CommandStringStash expectedCommandStringStash = new CommandStringStash(expectedCommandStringStack, 10);
+
+        commandStringStash.addCommandString("4");
+        assertEquals(expectedCommandStringStash, commandStringStash);
+    }
+
+    @Test
     public void addCommandString_withNullCommandString_throwsAssertionError() {
         CommandStringStash commandStringStash = new CommandStringStash();
         assertThrows(AssertionError.class, () -> commandStringStash.addCommandString(null));


### PR DESCRIPTION
Resolves #101.

If a command is repeated, the more recent version of the command will replace the older version so the user will not end up with several of the same commands in their history.
